### PR TITLE
raised the limit for MAX_GSTRINGS size by 100 percent

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -54,7 +54,7 @@ const (
 // MAX_GSTRINGS maximum number of stats entries that ethtool can
 // retrieve currently.
 const (
-	MAX_GSTRINGS = 100
+	MAX_GSTRINGS = 200
 )
 
 type ifreq struct {


### PR DESCRIPTION
Was working with solarflare cards and they returned a lot more stats than the
old value could handle.