### PR TITLE
Increase max_gstrings value

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -59,7 +59,7 @@ const (
 // MAX_GSTRINGS maximum number of stats entries that ethtool can
 // retrieve currently.
 const (
-	MAX_GSTRINGS = 200
+	MAX_GSTRINGS = 1000
 )
 
 type ifreq struct {


### PR DESCRIPTION
Bumping the value to 1000 to resolve this error with some room.
"map[] ethtool currently doesn't support more than 200 entries, received 729"