### PR TITLE
use generic Go facilities to get a socket

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -202,9 +202,9 @@ func (e *Ethtool) Close() {
 }
 
 func NewEthtool() (*Ethtool, error) {
-	fd, _, err := syscall.RawSyscall(syscall.SYS_SOCKET, syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_IP)
-	if err != 0 {
-		return nil, syscall.Errno(err)
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_IP)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Ethtool{


### PR DESCRIPTION
This PR uses `syscall.Socket` instead of the more low-level `RawSyscall` interface to obtain a socket descriptor. The former approach also works in i386, while the latter does not. See #15.
Closes #15.