### PR TITLE
Add exception handle for device speed -1

### DIFF
--- a/ethtool_cmd.go
+++ b/ethtool_cmd.go
@@ -26,6 +26,7 @@
 package ethtool
 
 import (
+	"math"
 	"reflect"
 	"syscall"
 	"unsafe"
@@ -128,6 +129,9 @@ func (e *Ethtool) CmdGet(ecmd *EthtoolCmd, intf string) (uint32, error) {
 
 	var speedval uint32 = (uint32(ecmd.Speed_hi) << 16) |
 		(uint32(ecmd.Speed) & 0xffff)
+	if speedval == math.MaxUint16 {
+		speedval = math.MaxUint32
+	}
 
 	return speedval, nil
 }
@@ -153,6 +157,9 @@ func (e *Ethtool) CmdSet(ecmd *EthtoolCmd, intf string) (uint32, error) {
 
 	var speedval uint32 = (uint32(ecmd.Speed_hi) << 16) |
 		(uint32(ecmd.Speed) & 0xffff)
+	if speedval == math.MaxUint16 {
+		speedval = math.MaxUint32
+	}
 
 	return speedval, nil
 }


### PR DESCRIPTION
When device speed is -1, we'd better set it to math.MaxUint32.