### PR TITLE
Fix garbled statistics names

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -29,6 +29,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -473,7 +474,7 @@ func (e *Ethtool) Stats(intf string) (map[string]uint64, error) {
 	var result = make(map[string]uint64)
 	for i := 0; i != int(drvinfo.n_stats); i++ {
 		b := gstrings.data[i*ETH_GSTRING_LEN : i*ETH_GSTRING_LEN+ETH_GSTRING_LEN]
-		key := string(bytes.Trim(b, "\x00"))
+		key := string(b[:strings.Index(string(b), "\x00")])
 		if len(key) != 0 {
 			result[key] = stats.data[i]
 		}


### PR DESCRIPTION
Stats are null terminated strings, but output may contain garbage between them. Current code
that converts C strings to Go strings doesn't handle these cases, as it only trims zeros at the
end of the string.

Fix based on: https://stackoverflow.com/a/12377539

Fixes: #4

Signed-off-by: Haggai Eran <haggai.eran@gmail.com>