### PR TITLE
New methods (GetCoalesce, GetChannels). Switched to golang.org/x/sys from syscall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: go
+
+before_script:
+  - go get golang.org/x/sys/unix

--- a/ethtool.go
+++ b/ethtool.go
@@ -118,16 +118,31 @@ type ethtoolSfeatures struct {
 	blocks [MAX_FEATURE_BLOCKS]ethtoolSetFeaturesBlock
 }
 
+type ethtoolDrvInfo struct {
+	cmd          uint32
+	driver       [32]byte
+	version      [32]byte
+	fw_version   [32]byte
+	bus_info     [32]byte
+	erom_version [32]byte
+	reserved2    [12]byte
+	n_priv_flags uint32
+	n_stats      uint32
+	testinfo_len uint32
+	eedump_len   uint32
+	regdump_len  uint32
+}
+
 // DrvInfo contains driver information
 // ethtool.h v3.5: struct ethtool_drvinfo
 type DrvInfo struct {
 	Cmd         uint32
-	Driver      [32]byte
-	Version     [32]byte
-	FwVersion   [32]byte
-	BusInfo     [32]byte
-	EromVersion [32]byte
-	Reserved2   [12]byte
+	Driver      string
+	Version     string
+	FwVersion   string
+	BusInfo     string
+	EromVersion string
+	Reserved2   string
 	NPrivFlags  uint32
 	NStats      uint32
 	TestInfoLen uint32
@@ -224,7 +239,7 @@ func (e *Ethtool) DriverName(intf string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(bytes.Trim(info.Driver[:], "\x00")), nil
+	return string(bytes.Trim(info.driver[:], "\x00")), nil
 }
 
 // BusInfo returns the bus information of the given interface name.
@@ -233,7 +248,7 @@ func (e *Ethtool) BusInfo(intf string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(bytes.Trim(info.BusInfo[:], "\x00")), nil
+	return string(bytes.Trim(info.bus_info[:], "\x00")), nil
 }
 
 // ModuleEeprom returns Eeprom information of the given interface name.
@@ -258,9 +273,24 @@ func (e *Ethtool) ModuleEepromHex(intf string) (string, error) {
 
 // DriverInfo returns driver information of the given interface name.
 func (e *Ethtool) DriverInfo(intf string) (DrvInfo, error) {
-	drvInfo, err := e.getDriverInfo(intf)
+	i, err := e.getDriverInfo(intf)
 	if err != nil {
 		return DrvInfo{}, err
+	}
+
+	drvInfo := DrvInfo{
+		Cmd:         i.cmd,
+		Driver:      string(bytes.Trim(i.driver[:], "\x00")),
+		Version:     string(bytes.Trim(i.version[:], "\x00")),
+		FwVersion:   string(bytes.Trim(i.fw_version[:], "\x00")),
+		BusInfo:     string(bytes.Trim(i.bus_info[:], "\x00")),
+		EromVersion: string(bytes.Trim(i.erom_version[:], "\x00")),
+		Reserved2:   string(bytes.Trim(i.reserved2[:], "\x00")),
+		NPrivFlags:  i.n_priv_flags,
+		NStats:      i.n_stats,
+		TestInfoLen: i.testinfo_len,
+		EedumpLen:   i.eedump_len,
+		RegdumpLen:  i.regdump_len,
 	}
 
 	return drvInfo, nil
@@ -325,13 +355,13 @@ func (e *Ethtool) ioctl(intf string, data uintptr) error {
 	return nil
 }
 
-func (e *Ethtool) getDriverInfo(intf string) (DrvInfo, error) {
-	drvinfo := DrvInfo{
-		Cmd: ETHTOOL_GDRVINFO,
+func (e *Ethtool) getDriverInfo(intf string) (ethtoolDrvInfo, error) {
+	drvinfo := ethtoolDrvInfo{
+		cmd: ETHTOOL_GDRVINFO,
 	}
 
 	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&drvinfo))); err != nil {
-		return DrvInfo{}, err
+		return ethtoolDrvInfo{}, err
 	}
 
 	return drvinfo, nil
@@ -526,22 +556,22 @@ func (e *Ethtool) LinkState(intf string) (uint32, error) {
 
 // Stats retrieves stats of the given interface name.
 func (e *Ethtool) Stats(intf string) (map[string]uint64, error) {
-	drvinfo := DrvInfo{
-		Cmd: ETHTOOL_GDRVINFO,
+	drvinfo := ethtoolDrvInfo{
+		cmd: ETHTOOL_GDRVINFO,
 	}
 
 	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&drvinfo))); err != nil {
 		return nil, err
 	}
 
-	if drvinfo.NStats*ETH_GSTRING_LEN > MAX_GSTRINGS*ETH_GSTRING_LEN {
-		return nil, fmt.Errorf("ethtool currently doesn't support more than %d entries, received %d", MAX_GSTRINGS, drvinfo.NStats)
+	if drvinfo.n_stats*ETH_GSTRING_LEN > MAX_GSTRINGS*ETH_GSTRING_LEN {
+		return nil, fmt.Errorf("ethtool currently doesn't support more than %d entries, received %d", MAX_GSTRINGS, drvinfo.n_stats)
 	}
 
 	gstrings := ethtoolGStrings{
 		cmd:        ETHTOOL_GSTRINGS,
 		string_set: ETH_SS_STATS,
-		len:        drvinfo.NStats,
+		len:        drvinfo.n_stats,
 		data:       [MAX_GSTRINGS * ETH_GSTRING_LEN]byte{},
 	}
 
@@ -551,7 +581,7 @@ func (e *Ethtool) Stats(intf string) (map[string]uint64, error) {
 
 	stats := ethtoolStats{
 		cmd:     ETHTOOL_GSTATS,
-		n_stats: drvinfo.NStats,
+		n_stats: drvinfo.n_stats,
 		data:    [MAX_GSTRINGS]uint64{},
 	}
 
@@ -560,7 +590,7 @@ func (e *Ethtool) Stats(intf string) (map[string]uint64, error) {
 	}
 
 	var result = make(map[string]uint64)
-	for i := 0; i != int(drvinfo.NStats); i++ {
+	for i := 0; i != int(drvinfo.n_stats); i++ {
 		b := gstrings.data[i*ETH_GSTRING_LEN : i*ETH_GSTRING_LEN+ETH_GSTRING_LEN]
 		key := string(b[:strings.Index(string(b), "\x00")])
 		if len(key) != 0 {

--- a/ethtool.go
+++ b/ethtool.go
@@ -30,8 +30,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 // Maximum size of an interface name
@@ -316,9 +317,9 @@ func (e *Ethtool) ioctl(intf string, data uintptr) error {
 		ifr_data: data,
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd), SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd), SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return syscall.Errno(ep)
+		return ep
 	}
 
 	return nil
@@ -572,12 +573,12 @@ func (e *Ethtool) Stats(intf string) (map[string]uint64, error) {
 
 // Close closes the ethool handler
 func (e *Ethtool) Close() {
-	syscall.Close(e.fd)
+	unix.Close(e.fd)
 }
 
 // NewEthtool returns a new ethtool handler
 func NewEthtool() (*Ethtool, error) {
-	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_IP)
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, unix.IPPROTO_IP)
 	if err != nil {
 		return nil, err
 	}

--- a/ethtool_cmd.go
+++ b/ethtool_cmd.go
@@ -28,8 +28,9 @@ package ethtool
 import (
 	"math"
 	"reflect"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 type EthtoolCmd struct { /* ethtool.c: struct ethtool_cmd */
@@ -121,10 +122,10 @@ func (e *Ethtool) CmdGet(ecmd *EthtoolCmd, intf string) (uint32, error) {
 		ifr_data: uintptr(unsafe.Pointer(ecmd)),
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return 0, syscall.Errno(ep)
+		return 0, ep
 	}
 
 	var speedval uint32 = (uint32(ecmd.Speed_hi) << 16) |
@@ -149,10 +150,10 @@ func (e *Ethtool) CmdSet(ecmd *EthtoolCmd, intf string) (uint32, error) {
 		ifr_data: uintptr(unsafe.Pointer(ecmd)),
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return 0, syscall.Errno(ep)
+		return 0, unix.Errno(ep)
 	}
 
 	var speedval uint32 = (uint32(ecmd.Speed_hi) << 16) |
@@ -178,10 +179,10 @@ func (e *Ethtool) CmdGetMapped(intf string) (map[string]uint64, error) {
 		ifr_data: uintptr(unsafe.Pointer(&ecmd)),
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return nil, syscall.Errno(ep)
+		return nil, ep
 	}
 
 	var result = make(map[string]uint64)

--- a/ethtool_msglvl.go
+++ b/ethtool_msglvl.go
@@ -26,8 +26,9 @@
 package ethtool
 
 import (
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 type ethtoolValue struct { /* ethtool.c: struct ethtool_value */
@@ -49,10 +50,10 @@ func (e *Ethtool) MsglvlGet(intf string) (uint32, error) {
 		ifr_data: uintptr(unsafe.Pointer(&edata)),
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return 0, syscall.Errno(ep)
+		return 0, ep
 	}
 
 	return edata.data, nil
@@ -72,10 +73,10 @@ func (e *Ethtool) MsglvlSet(intf string, valset uint32) (uint32, uint32, error) 
 		ifr_data: uintptr(unsafe.Pointer(&edata)),
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return 0, 0, syscall.Errno(ep)
+		return 0, 0, ep
 	}
 
 	readval := edata.data
@@ -83,10 +84,10 @@ func (e *Ethtool) MsglvlSet(intf string, valset uint32) (uint32, uint32, error) 
 	edata.cmd = ETHTOOL_SMSGLVL
 	edata.data = valset
 
-	_, _, ep = syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep = unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return 0, 0, syscall.Errno(ep)
+		return 0, 0, ep
 	}
 
 	return readval, edata.data, nil


### PR DESCRIPTION
Added methods to retrieve channels count, coalesce config params.
Changed DriverInfo method to return an exported struct.
Switched to golang.org/x/sys/unix from syscall. https://groups.google.com/forum/#!topic/golang-dev/cEASnHIXmLI
package syscall is locked down and should only be called by internal packages, external packages should use golang.org/x/sys

@safchain - Can this be merged?