### PR TITLE
fix panic if key without padding

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -614,7 +614,11 @@ func (e *Ethtool) Stats(intf string) (map[string]uint64, error) {
 	var result = make(map[string]uint64)
 	for i := 0; i != int(drvinfo.n_stats); i++ {
 		b := gstrings.data[i*ETH_GSTRING_LEN : i*ETH_GSTRING_LEN+ETH_GSTRING_LEN]
-		key := string(b[:strings.Index(string(b), "\x00")])
+		strEnd := strings.Index(string(b), "\x00")
+		if strEnd == -1 {
+			strEnd = ETH_GSTRING_LEN
+		}
+		key := string(b[:strEnd])
 		if len(key) != 0 {
 			result[key] = stats.data[i]
 		}


### PR DESCRIPTION
For example mlxsw_spectrum has 'a_mac_control_frames_transmitted' key, which triggers panic because there is no \x00 padding.