### PR TITLE
AddingPowerSupportFor_golang-github-safchain-ethtool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: go
 
 before_script:


### PR DESCRIPTION
Adding Power Support.

Adding power support ppc64le
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, Please find the Travis Link: https://travis-ci.com/github/santosh653/ethtool

Please Let me know if you need any other details or If I am missing any..
Thank You !!