### PR TITLE
Update MAX_GSTRINGS to 16384

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -76,7 +76,7 @@ const (
 // MAX_GSTRINGS maximum number of stats entries that ethtool can
 // retrieve currently.
 const (
-	MAX_GSTRINGS       = 8192
+	MAX_GSTRINGS       = 16384
 	MAX_FEATURE_BLOCKS = (MAX_GSTRINGS + 32 - 1) / 32
 	EEPROM_LEN         = 640
 	PERMADDR_LEN       = 32


### PR DESCRIPTION
When attempting to use the ethtool stats collector in prometheus node exporter which leverages this lib, I'm hitting the 8k limit set in MAX_GSTRINGS due to NICs with a large number of channels and rx/tx queues due to overall system core counts (i.e. 128 cpu cores). This increases the overall number of stats exported:
```
Aug 03 00:02:08 node_exporter[1728339]: level=error ts=2021-08-03T00:02:08.271Z caller=ethtool_linux.go:154 collector=ethtool msg="ethtool stats error" err="ethtool currently doesn't support more than 8192 entries, received 8979">
```

This PR raises the MAX_GSTRINGS limit to 16k. 