### PR TITLE
Add Names for supported capabilities of interfaces

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -725,7 +725,7 @@ func PermAddr(intf string) (string, error) {
 
 // SupportedLinkModes returns the names of the link modes supported by the interface.
 func SupportedLinkModes(mask uint64) []string {
-	ret := make([]string, 0)
+	var ret []string
 	for _, mode := range SupportedCapabilities {
 		if mode.mask&mask != 0 {
 			ret = append(ret, mode.name)
@@ -736,7 +736,7 @@ func SupportedLinkModes(mask uint64) []string {
 
 // SupportedMaxCapacity returns the maximum capacity of this interface.
 func SupportedMaxCapacity(mask uint64) uint64 {
-	ret := uint64(0)
+	var ret uint64
 	for _, mode := range SupportedLinkModes(mask) {
 		if cap, ok := Capacities[mode]; ok && cap > ret {
 			ret = cap

--- a/ethtool.go
+++ b/ethtool.go
@@ -719,7 +719,7 @@ func SupportedLinkModes(mask uint64) []string {
 	return ret
 }
 
-// SupportedMaxCapacity return the maximum capacity of this interface.
+// SupportedMaxCapacity returns the maximum capacity of this interface.
 func SupportedMaxCapacity(mask uint64) uint64 {
 	ret := uint64(0)
 	for _, mode := range SupportedCapacities {

--- a/ethtool.go
+++ b/ethtool.go
@@ -717,3 +717,13 @@ func SupportedReadable(mask uint64) []string {
 	}
 	return ret
 }
+
+func SupportedMaxCapacity(mask uint64) uint64 {
+	ret := uint64(0)
+	for _, mode := range SupportedCapacities {
+		if mode.mask&mask != 0 {
+			ret = mode.capacity
+		}
+	}
+	return ret
+}

--- a/ethtool.go
+++ b/ethtool.go
@@ -82,6 +82,21 @@ const (
 	PERMADDR_LEN       = 32
 )
 
+// see https://github.com/lyonel/lshw/blob/fdab06ac0b190ea0aa02cd468f904ed69ce0d9f1/src/core/network.cc#L113
+var SupportedCapacities = []struct {
+	name     string
+	mask     uint64
+	capacity uint64
+}{
+	{"10baseT_Half", (1 << 0), 10_000_000},
+	{"10baseT_Full", (1 << 1), 10_000_000},
+	{"100baseT_Half", (1 << 2), 100_000_000},
+	{"100baseT_Full", (1 << 3), 100_000_000},
+	{"1000baseT_Half", (1 << 4), 1_000_000_000},
+	{"1000baseT_Full", (1 << 5), 1_000_000_000},
+	{"10000baseT_Full", (1 << 12), 10_000_000_000},
+}
+
 type ifreq struct {
 	ifr_name [IFNAMSIZ]byte
 	ifr_data uintptr
@@ -691,4 +706,14 @@ func PermAddr(intf string) (string, error) {
 	}
 	defer e.Close()
 	return e.PermAddr(intf)
+}
+
+func SupportedReadable(mask uint64) []string {
+	ret := make([]string, 0)
+	for _, mode := range SupportedCapacities {
+		if mode.mask&mask != 0 {
+			ret = append(ret, mode.name)
+		}
+	}
+	return ret
 }

--- a/ethtool.go
+++ b/ethtool.go
@@ -734,8 +734,8 @@ func SupportedLinkModes(mask uint64) []string {
 	return ret
 }
 
-// SupportedMaxCapacity returns the maximum capacity of this interface.
-func SupportedMaxCapacity(mask uint64) uint64 {
+// SupportedSpeed returns the maximum capacity of this interface.
+func SupportedSpeed(mask uint64) uint64 {
 	var ret uint64
 	for _, mode := range SupportedLinkModes(mask) {
 		if cap, ok := Capacities[mode]; ok && cap > ret {

--- a/ethtool.go
+++ b/ethtool.go
@@ -83,18 +83,33 @@ const (
 )
 
 // see https://github.com/lyonel/lshw/blob/fdab06ac0b190ea0aa02cd468f904ed69ce0d9f1/src/core/network.cc#L113
-var SupportedCapacities = []struct {
-	name     string
-	mask     uint64
-	capacity uint64
+var SupportedCapabilities = []struct {
+	name string
+	mask uint64
 }{
-	{"10baseT_Half", (1 << 0), 10_000_000},
-	{"10baseT_Full", (1 << 1), 10_000_000},
-	{"100baseT_Half", (1 << 2), 100_000_000},
-	{"100baseT_Full", (1 << 3), 100_000_000},
-	{"1000baseT_Half", (1 << 4), 1_000_000_000},
-	{"1000baseT_Full", (1 << 5), 1_000_000_000},
-	{"10000baseT_Full", (1 << 12), 10_000_000_000},
+	{"10baseT_Half", (1 << 0)},
+	{"10baseT_Full", (1 << 1)},
+	{"100baseT_Half", (1 << 2)},
+	{"100baseT_Full", (1 << 3)},
+	{"1000baseT_Half", (1 << 4)},
+	{"1000baseT_Full", (1 << 5)},
+	{"Autoneg", (1 << 6)},
+	{"TP", (1 << 7)},
+	{"AUI", (1 << 8)},
+	{"MII", (1 << 9)},
+	{"FIBRE", (1 << 10)},
+	{"BNC", (1 << 11)},
+	{"10000baseT_Full", (1 << 12)},
+}
+
+var Capacities = map[string]uint64{
+	"10baseT_Half":    10_000_000,
+	"10baseT_Full":    10_000_000,
+	"100baseT_Half":   100_000_000,
+	"100baseT_Full":   100_000_000,
+	"1000baseT_Half":  1_000_000_000,
+	"1000baseT_Full":  1_000_000_000,
+	"10000baseT_Full": 10_000_000_000,
 }
 
 type ifreq struct {
@@ -711,7 +726,7 @@ func PermAddr(intf string) (string, error) {
 // SupportedLinkModes returns the names of the link modes supported by the interface.
 func SupportedLinkModes(mask uint64) []string {
 	ret := make([]string, 0)
-	for _, mode := range SupportedCapacities {
+	for _, mode := range SupportedCapabilities {
 		if mode.mask&mask != 0 {
 			ret = append(ret, mode.name)
 		}
@@ -722,9 +737,9 @@ func SupportedLinkModes(mask uint64) []string {
 // SupportedMaxCapacity returns the maximum capacity of this interface.
 func SupportedMaxCapacity(mask uint64) uint64 {
 	ret := uint64(0)
-	for _, mode := range SupportedCapacities {
-		if mode.mask&mask != 0 {
-			ret = mode.capacity
+	for _, mode := range SupportedLinkModes(mask) {
+		if cap, ok := Capacities[mode]; ok && cap > ret {
+			ret = cap
 		}
 	}
 	return ret

--- a/ethtool.go
+++ b/ethtool.go
@@ -708,7 +708,8 @@ func PermAddr(intf string) (string, error) {
 	return e.PermAddr(intf)
 }
 
-func SupportedReadable(mask uint64) []string {
+// SupportedLinkModes returns the names of the link modes supported by the interface.
+func SupportedLinkModes(mask uint64) []string {
 	ret := make([]string, 0)
 	for _, mode := range SupportedCapacities {
 		if mode.mask&mask != 0 {
@@ -718,6 +719,7 @@ func SupportedReadable(mask uint64) []string {
 	return ret
 }
 
+// SupportedMaxCapacity return the maximum capacity of this interface.
 func SupportedMaxCapacity(mask uint64) uint64 {
 	ret := uint64(0)
 	for _, mode := range SupportedCapacities {

--- a/ethtool_test.go
+++ b/ethtool_test.go
@@ -112,7 +112,7 @@ func TestSupportedLinkModes(t *testing.T) {
 		inputMask uint64
 		expected  []string
 	}{
-		{0b01100010_11101111, []string{"10baseT_Half", "10baseT_Full", "100baseT_Half", "100baseT_Full", "1000baseT_Full", "Autoneg", "TP", "MII"}},
+		{0b01100010_11101111, []string{"10baseT_Half", "10baseT_Full", "100baseT_Half", "100baseT_Full", "1000baseT_Full"}},
 	}
 
 	for _, testcase := range cases {

--- a/ethtool_test.go
+++ b/ethtool_test.go
@@ -23,6 +23,7 @@ package ethtool
 
 import (
 	"net"
+	"reflect"
 	"testing"
 )
 
@@ -103,5 +104,21 @@ func TestBusInfo(t *testing.T) {
 
 	if !success {
 		t.Fatal("Unable to retrieve bus info from any interface of this system.")
+	}
+}
+
+func TestSupportedLinkModes(t *testing.T) {
+	var cases = []struct {
+		inputMask uint64
+		expected  []string
+	}{
+		{0b01100010_11101111, []string{"10baseT_Half", "10baseT_Full", "100baseT_Half", "100baseT_Full", "1000baseT_Full", "Autoneg", "TP", "MII"}},
+	}
+
+	for _, testcase := range cases {
+		actual := SupportedLinkModes(testcase.inputMask)
+		if !reflect.DeepEqual(actual, testcase.expected) {
+			t.Error("Expected ", testcase.expected, " got ", actual)
+		}
 	}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -51,7 +51,7 @@ func main() {
 		panic(err.Error())
 	}
 	fmt.Printf("cmd get: %+v\n", cmdGet)
-	fmt.Printf("max capacity: %+v\n", ethtool.SupportedMaxCapacity(cmdGet["Supported"]))
+	fmt.Printf("max capacity: %+v\n", ethtool.SupportedSpeed(cmdGet["Supported"]))
 
 	msgLvlGet, err := e.MsglvlGet(*name)
 	if err != nil {

--- a/example/main.go
+++ b/example/main.go
@@ -51,6 +51,7 @@ func main() {
 		panic(err.Error())
 	}
 	fmt.Printf("cmd get: %+v\n", cmdGet)
+	fmt.Printf("max capacity: %+v\n", ethtool.SupportedMaxCapacity(cmdGet["Supported"]))
 
 	msgLvlGet, err := e.MsglvlGet(*name)
 	if err != nil {


### PR DESCRIPTION
Currently, one can acquire a bitmask of supported modes of operation by using the `GetCmdMapped` function:

```go
e, err := ethtool.NewEthtool()
if err != nil {
	panic(err.Error())
}
defer e.Close()
cmdGet, err := e.CmdGetMapped(*name)
if err != nil {
	panic(err.Error())
}
fmt.Printf("cmd get: %+d\n", cmdGet["Supported"])
```

Unfortunately, there is no information on what the individual bits mean. 

In this PR, I added the names of some supported capabilities (which I got from here: https://github.com/lyonel/lshw/blob/fdab06ac0b190ea0aa02cd468f904ed69ce0d9f1/src/core/network.cc#L113). This enables users of this library to seamlessly check, which capacities the interface in question supports.

closes #46