### PR TITLE
Update MAX_GSTRINGS to 32768

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -76,7 +76,7 @@ const (
 // MAX_GSTRINGS maximum number of stats entries that ethtool can
 // retrieve currently.
 const (
-	MAX_GSTRINGS       = 16384
+	MAX_GSTRINGS       = 32768
 	MAX_FEATURE_BLOCKS = (MAX_GSTRINGS + 32 - 1) / 32
 	EEPROM_LEN         = 640
 	PERMADDR_LEN       = 32


### PR DESCRIPTION
As stated in Issue #45, the number of entries from ethtool stats can go beyond the current `MAX_GSTRINGS` limit with some firmware versions from certain NIC vendors. One example is Mellanox MT27800 ConnectX-5 with the following firmware.

```
$ ethtool -i enp1s0f0
driver: mlx5_core
version: 5.1-2.3.7
firmware-version: 16.28.4512 (DEL0000000016)
expansion-rom-version:
bus-info: 0000:01:00.0
supports-statistics: yes
supports-test: yes
supports-eeprom-access: no
supports-register-dump: no
supports-priv-flags: yes
``` 

Before the change (with added logs to show the error and # of entries):
```
[stephen@ld1 ethtool]$ go test -run TestStats -v
=== RUN   TestStats
 Interface lo, err: operation not supported
 Interface em1, len(stats) 72
 Interface enp1s0f0, err: ethtool currently doesn't support more than 16384 entries, received 19338 <<<<<
 Interface enp1s0f1, len(stats) 5910
--- PASS: TestStats (0.00s)
PASS
ok      _/export/home/stephen/ethtool     0.006s
```

After the change:
```
[stephen@ld1 ethtool]$ go test -run TestStats -v
=== RUN   TestStats
 Interface lo, err: operation not supported
 Interface em1, len(stats) 72
 Interface enp1s0f0, len(stats) 19140
 Interface enp1s0f1, len(stats) 5910
--- PASS: TestStats (0.01s)
PASS
ok      _/export/home/stephen/ethtool     0.015s
```