### PR TITLE
Added support for Indirection Table editing

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -404,7 +404,7 @@ type Indir struct {
 }
 
 type SetIndir struct {
-	Equal  uint8    //used to set number of cores
+	Equal  uint8    // used to set number of cores
 	Weight []uint32 // used to select cores
 }
 
@@ -683,14 +683,15 @@ func fillIndirTable(indirSize *uint32, indir []uint32, rxfhindirDefault int,
 	rxfhindirStart int, rxfhindirEqual int, rxfhindirWeight []uint32,
 	numWeights uint32) error {
 
-	if rxfhindirEqual != 0 {
+	switch {
+	case rxfhindirEqual != 0:
 		for i := uint32(0); i < *indirSize; i++ {
 			indir[i] = uint32(rxfhindirStart) + (i % uint32(rxfhindirEqual))
 		}
-	} else if rxfhindirWeight != nil {
-		var sum, partial, j, weight uint32 = 0, 0, 0, 0
-
-		for j = 0; j < numWeights; j++ {
+	case rxfhindirWeight != nil:
+		var sum, partial uint32 = 0, 0
+		var j, weight uint32
+		for j = range numWeights {
 			weight = rxfhindirWeight[j]
 			sum += weight
 		}
@@ -712,12 +713,11 @@ func fillIndirTable(indirSize *uint32, indir []uint32, rxfhindirDefault int,
 			}
 			indir[i] = uint32(rxfhindirStart) + j
 		}
-	} else if rxfhindirDefault != 0 {
+	case rxfhindirDefault != 0:
 		*indirSize = 0
-	} else {
+	default:
 		*indirSize = ETH_RXFH_INDIR_NO_CHANGE
 	}
-
 	return nil
 }
 

--- a/ethtool.go
+++ b/ethtool.go
@@ -404,8 +404,8 @@ type Indir struct {
 }
 
 type SetIndir struct {
-	Equal  uint8             //used to set number of cores
-	Weight [MAX_CORES]uint32 // used to select cores
+	Equal  uint8    //used to set number of cores
+	Weight []uint32 // used to select cores
 }
 
 // Convert zero-terminated array of chars (string in C) to a Go string.
@@ -493,7 +493,7 @@ func (e *Ethtool) GetIndir(intf string) (Indir, error) {
 // SetIndir sets the indirection table of the given interface from the SetIndir struct
 func (e *Ethtool) SetIndir(intf string, setIndir SetIndir) (Indir, error) {
 
-	if setIndir.Equal != 0 && setIndir.Weight != [MAX_CORES]uint32{0} {
+	if setIndir.Equal != 0 && setIndir.Weight != nil {
 		return Indir{}, fmt.Errorf("equal and weight options are mutually exclusive")
 	}
 
@@ -661,7 +661,7 @@ func (e *Ethtool) getIndir(intf string) (Indir, error) {
 // parsing of do_srxfhindir from ethtool.c
 func (e *Ethtool) setIndir(intf string, indir Indir, setIndir SetIndir) (Indir, error) {
 
-	err := fillIndirTable(&indir.Size, indir.RingIndex[:], 0, 0, int(setIndir.Equal), setIndir.Weight, MAX_CORES)
+	err := fillIndirTable(&indir.Size, indir.RingIndex[:], 0, 0, int(setIndir.Equal), setIndir.Weight, uint32(len(setIndir.Weight)))
 	if err != nil {
 		return Indir{}, err
 	}
@@ -680,14 +680,14 @@ func (e *Ethtool) setIndir(intf string, indir Indir, setIndir SetIndir) (Indir, 
 }
 
 func fillIndirTable(indirSize *uint32, indir []uint32, rxfhindirDefault int,
-	rxfhindirStart int, rxfhindirEqual int, rxfhindirWeight [MAX_CORES]uint32,
+	rxfhindirStart int, rxfhindirEqual int, rxfhindirWeight []uint32,
 	numWeights uint32) error {
 
 	if rxfhindirEqual != 0 {
 		for i := uint32(0); i < *indirSize; i++ {
 			indir[i] = uint32(rxfhindirStart) + (i % uint32(rxfhindirEqual))
 		}
-	} else if rxfhindirWeight != [MAX_CORES]uint32{0} {
+	} else if rxfhindirWeight != nil {
 		var sum, partial, j, weight uint32 = 0, 0, 0, 0
 
 		for j = 0; j < numWeights; j++ {

--- a/ethtool_test.go
+++ b/ethtool_test.go
@@ -179,7 +179,7 @@ func TestIndir(t *testing.T) {
 	if err != nil || indir.RingIndex == [256]uint32{} {
 		t.Fatal(err)
 	}
-	//Set either equal or set weight
+	// Set either equal or set weight
 	setIndir := SetIndir{}
 	// setIndir.Equal = 10
 	setIndir.Weight = make([]uint32, 32)

--- a/ethtool_test.go
+++ b/ethtool_test.go
@@ -166,76 +166,26 @@ func TestFeatures(t *testing.T) {
 	}
 }
 
-func TestChannels(t *testing.T) {
-	et, err := NewEthtool()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer et.Close()
-
-	channels, err := et.getChannels("enp52s0f1np1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if channels == (Channels{}) {
-		t.Fatalf("expected channels for interface")
-	}
-
-	if channels.MaxRx != 0 || channels.MaxTx != 0 || channels.MaxOther != 0 {
-		t.Fatalf("unexpected channel values: %v", channels)
-	}
-	if channels.RxCount != 0 || channels.TxCount != 0 || channels.OtherCount != 0 {
-		t.Fatalf("unexpected channel values: %v", channels)
-	}
-	t.Log(channels)
-}
-
-func TestRing(t *testing.T) {
-	et, err := NewEthtool()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer et.Close()
-
-	rings, err := et.GetRing("enp52s0f1np1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if rings == (Ring{}) {
-		t.Fatalf("expected rings for interface")
-	}
-
-	t.Log(rings)
-}
-
 func TestIndir(t *testing.T) {
 	et, err := NewEthtool()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer et.Close()
-
-	indir, err := et.GetIndir("enp52s0f1np1")
-	if err != nil {
+	ifname := "enp52s0f1np1"
+	indir, err := et.GetIndir(ifname)
+	if err != nil || indir.RingIndex == [256]uint32{} {
 		t.Fatal(err)
 	}
-	t.Log(indir)
-
-	// if indir == (Indir{}) {
-	// 	t.Fatalf("expected indir for interface")
-	// }
-
+	//Set either equal or set weight
 	setIndir := SetIndir{}
-	setIndir.Equal = 10
-	// setIndir.Weight[0] = 1
-	// setIndir.Weight[1] = 1
+	// setIndir.Equal = 10
+	setIndir.Weight = make([]uint32, 32)
+	setIndir.Weight[0] = 1
+	setIndir.Weight[1] = 1
 
-	newindir, err := et.SetIndir("enp52s0f1np1", setIndir)
-	if err != nil {
+	newindir, err := et.SetIndir(ifname, setIndir)
+	if err != nil || newindir.RingIndex == [256]uint32{} {
 		t.Fatal(err)
 	}
-
-	t.Log(newindir)
 }

--- a/ethtool_test.go
+++ b/ethtool_test.go
@@ -165,29 +165,3 @@ func TestFeatures(t *testing.T) {
 		t.Fatalf("loopback interface reported all features available")
 	}
 }
-
-func TestIndir(t *testing.T) {
-	et, err := NewEthtool()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer et.Close()
-	// Set with your interface name
-	ifname := "enp52s0f1np1"
-
-	indir, err := et.GetIndir(ifname)
-	if err != nil || indir.RingIndex == [256]uint32{} {
-		t.Fatal(err)
-	}
-	// Set either equal or set weight
-	setIndir := SetIndir{}
-	// setIndir.Equal = 10
-	setIndir.Weight = make([]uint32, 32)
-	setIndir.Weight[0] = 1
-	setIndir.Weight[1] = 1
-
-	newindir, err := et.SetIndir(ifname, setIndir)
-	if err != nil || newindir.RingIndex == [256]uint32{} {
-		t.Fatal(err)
-	}
-}

--- a/ethtool_test.go
+++ b/ethtool_test.go
@@ -165,3 +165,77 @@ func TestFeatures(t *testing.T) {
 		t.Fatalf("loopback interface reported all features available")
 	}
 }
+
+func TestChannels(t *testing.T) {
+	et, err := NewEthtool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer et.Close()
+
+	channels, err := et.getChannels("enp52s0f1np1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if channels == (Channels{}) {
+		t.Fatalf("expected channels for interface")
+	}
+
+	if channels.MaxRx != 0 || channels.MaxTx != 0 || channels.MaxOther != 0 {
+		t.Fatalf("unexpected channel values: %v", channels)
+	}
+	if channels.RxCount != 0 || channels.TxCount != 0 || channels.OtherCount != 0 {
+		t.Fatalf("unexpected channel values: %v", channels)
+	}
+	t.Log(channels)
+}
+
+func TestRing(t *testing.T) {
+	et, err := NewEthtool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer et.Close()
+
+	rings, err := et.GetRing("enp52s0f1np1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rings == (Ring{}) {
+		t.Fatalf("expected rings for interface")
+	}
+
+	t.Log(rings)
+}
+
+func TestIndir(t *testing.T) {
+	et, err := NewEthtool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer et.Close()
+
+	indir, err := et.GetIndir("enp52s0f1np1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(indir)
+
+	// if indir == (Indir{}) {
+	// 	t.Fatalf("expected indir for interface")
+	// }
+
+	setIndir := SetIndir{}
+	setIndir.Equal = 10
+	// setIndir.Weight[0] = 1
+	// setIndir.Weight[1] = 1
+
+	newindir, err := et.SetIndir("enp52s0f1np1", setIndir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(newindir)
+}

--- a/ethtool_test.go
+++ b/ethtool_test.go
@@ -172,7 +172,9 @@ func TestIndir(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer et.Close()
+	// Set with your interface name
 	ifname := "enp52s0f1np1"
+
 	indir, err := et.GetIndir(ifname)
 	if err != nil || indir.RingIndex == [256]uint32{} {
 		t.Fatal(err)


### PR DESCRIPTION
The following changes introduce support for Indirection Table editing similar to the functionality provided by the following `ethtool` CLI commands:
 ```sudo ethtool --set-rxfh-indir $ETH equal 10``` or ```sudo ethtool --set-rxfh-indir $ETH weight 1 1```

- New functions:  ```GetIndir```, ```SetIndir```, ```fillIndirTable``` 
- New structs: ```Indir``` and ```SetIndir```

The ```GetIndir(intf string)``` function retrieves the current Indirection Table for the specified network interface, and returns an ```Indir```struct.

The ```SetIndir(intf string, setIndir SetIndir)``` function sets a new Indirection Table for the specified interface. The function accepts a ```SetIndir``` struct, which should have either: ```SetIndir.Equal``` value set or ```SetIndir.Weight``` slice set.

The function then calls the ```fillIndirTable```, an Internal helper function that generates the Indirection Table based on the input parameters, following the same logic used in ```ethtool.c```.

An usage example can be seen in the```TestIndir(...)``` function  in ```ethtool_test.go```.