### PR TITLE
Added Link Settings (GLINKSETTINGS/SLINKSETTINGS) Support

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -54,13 +54,15 @@ const (
 	ETH_SS_FEATURES   = 4
 
 	// CMD supported
-	ETHTOOL_GSET     = 0x00000001 /* Get settings. */
-	ETHTOOL_SSET     = 0x00000002 /* Set settings. */
-	ETHTOOL_GWOL     = 0x00000005 /* Get wake-on-lan options. */
-	ETHTOOL_SWOL     = 0x00000006 /* Set wake-on-lan options. */
-	ETHTOOL_GDRVINFO = 0x00000003 /* Get driver info. */
-	ETHTOOL_GMSGLVL  = 0x00000007 /* Get driver message level */
-	ETHTOOL_SMSGLVL  = 0x00000008 /* Set driver msg level. */
+	ETHTOOL_GSET          = 0x00000001                 /* Get settings. */
+	ETHTOOL_SSET          = 0x00000002                 /* Set settings. */
+	ETHTOOL_GWOL          = 0x00000005                 /* Get wake-on-lan options. */
+	ETHTOOL_SWOL          = 0x00000006                 /* Set wake-on-lan options. */
+	ETHTOOL_GDRVINFO      = 0x00000003                 /* Get driver info. */
+	ETHTOOL_GMSGLVL       = 0x00000007                 /* Get driver message level */
+	ETHTOOL_SMSGLVL       = 0x00000008                 /* Set driver msg level. */
+	ETHTOOL_GLINKSETTINGS = unix.ETHTOOL_GLINKSETTINGS // 0x4c
+	ETHTOOL_SLINKSETTINGS = unix.ETHTOOL_SLINKSETTINGS // 0x4d
 
 	// Get link status for host, i.e. whether the interface *and* the
 	// physical port (if there is one) are up (ethtool_value).
@@ -89,6 +91,38 @@ const (
 	ETHTOOL_GRXFHINDIR       = 0x00000038 /* Get RX flow hash indir'n table */
 	ETHTOOL_SRXFHINDIR       = 0x00000039 /* Set RX flow hash indir'n table */
 	ETH_RXFH_INDIR_NO_CHANGE = 0xFFFFFFFF
+
+	// Speed and Duplex unknowns/constants (Manually defined based on <linux/ethtool.h>)
+	SPEED_UNKNOWN  = 0xffffffff // ((__u32)-1) SPEED_UNKNOWN
+	DUPLEX_HALF    = 0x00       // DUPLEX_HALF
+	DUPLEX_FULL    = 0x01       // DUPLEX_FULL
+	DUPLEX_UNKNOWN = 0xff       // DUPLEX_UNKNOWN
+
+	// Port types (Manually defined based on <linux/ethtool.h>)
+	PORT_TP    = 0x00 // PORT_TP
+	PORT_AUI   = 0x01 // PORT_AUI
+	PORT_MII   = 0x02 // PORT_MII
+	PORT_FIBRE = 0x03 // PORT_FIBRE
+	PORT_BNC   = 0x04 // PORT_BNC
+	PORT_DA    = 0x05 // PORT_DA
+	PORT_NONE  = 0xef // PORT_NONE
+	PORT_OTHER = 0xff // PORT_OTHER
+
+	// Autoneg settings (Manually defined based on <linux/ethtool.h>)
+	AUTONEG_DISABLE = 0x00 // AUTONEG_DISABLE
+	AUTONEG_ENABLE  = 0x01 // AUTONEG_ENABLE
+
+	// MDIX states (Manually defined based on <linux/ethtool.h>)
+	ETH_TP_MDI_INVALID = 0x00 // ETH_TP_MDI_INVALID
+	ETH_TP_MDI         = 0x01 // ETH_TP_MDI
+	ETH_TP_MDI_X       = 0x02 // ETH_TP_MDI_X
+	ETH_TP_MDI_AUTO    = 0x03 // Control value ETH_TP_MDI_AUTO
+
+	// Link mode mask bits count (Manually defined based on ethtool.h)
+	ETHTOOL_LINK_MODE_MASK_NBITS = 92 // __ETHTOOL_LINK_MODE_MASK_NBITS
+
+	// Calculate max nwords based on NBITS using the manually defined constant
+	MAX_LINK_MODE_MASK_NWORDS = (ETHTOOL_LINK_MODE_MASK_NBITS + 31) / 32 // = 3
 )
 
 // MAX_GSTRINGS maximum number of stats entries that ethtool can
@@ -1253,7 +1287,7 @@ func supportedSpeeds(mask uint64) (ret []struct {
 	speed uint64
 }) {
 	for _, mode := range supportedCapabilities {
-		if ((1 << mode.mask) & mask) != 0 {
+		if mode.speed > 0 && ((1<<mode.mask)&mask) != 0 {
 			ret = append(ret, mode)
 		}
 	}

--- a/ethtool_link_settings.go
+++ b/ethtool_link_settings.go
@@ -1,0 +1,327 @@
+package ethtool
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// EthtoolLinkSettingsFixed corresponds to struct ethtool_link_settings fixed part
+type EthtoolLinkSettingsFixed struct {
+	Cmd                 uint32
+	Speed               uint32
+	Duplex              uint8
+	Port                uint8
+	PhyAddress          uint8
+	Autoneg             uint8
+	MdixSupport         uint8 // Renamed from mdio_support
+	EthTpMdix           uint8
+	EthTpMdixCtrl       uint8
+	LinkModeMasksNwords int8
+	Transceiver         uint8
+	MasterSlaveCfg      uint8
+	MasterSlaveState    uint8
+	Reserved1           [1]byte
+	Reserved            [7]uint32
+	// Flexible array member link_mode_masks[0] starts here implicitly
+}
+
+// ethtoolLinkSettingsRequest includes space for the flexible array members
+type ethtoolLinkSettingsRequest struct {
+	Settings EthtoolLinkSettingsFixed
+	Masks    [3 * MAX_LINK_MODE_MASK_NWORDS]uint32 // Uses MAX_LINK_MODE_MASK_NWORDS constant from ethtool.go
+}
+
+// LinkSettings is the user-friendly representation returned by GetLinkSettings
+type LinkSettings struct {
+	Speed                uint32
+	Duplex               uint8
+	Port                 uint8
+	PhyAddress           uint8
+	Autoneg              uint8
+	MdixSupport          uint8
+	EthTpMdix            uint8
+	EthTpMdixCtrl        uint8
+	Transceiver          uint8
+	MasterSlaveCfg       uint8
+	MasterSlaveState     uint8
+	SupportedLinkModes   []string
+	AdvertisingLinkModes []string
+	LpAdvertisingModes   []string
+	Source               string // "GSET" or "GLINKSETTINGS"
+}
+
+// GetLinkSettings retrieves link settings, preferring ETHTOOL_GLINKSETTINGS and falling back to ETHTOOL_GSET.
+// Uses a single ioctl call with the maximum expected buffer size.
+func (e *Ethtool) GetLinkSettings(intf string) (*LinkSettings, error) {
+	// 1. Attempt ETHTOOL_GLINKSETTINGS with max buffer size
+	var req ethtoolLinkSettingsRequest
+	req.Settings.Cmd = ETHTOOL_GLINKSETTINGS
+	// Provide the maximum expected nwords based on our constant
+	req.Settings.LinkModeMasksNwords = int8(MAX_LINK_MODE_MASK_NWORDS)
+
+	err := e.ioctl(intf, uintptr(unsafe.Pointer(&req)))
+	attemptFallback := false
+	fallbackReason := ""
+
+	// Condition 1: ioctl returned EOPNOTSUPP
+	if errno, ok := err.(syscall.Errno); ok && errno == unix.EOPNOTSUPP {
+		attemptFallback = true
+		fallbackReason = "EOPNOTSUPP"
+	} else if err == nil {
+		// Condition 2: ioctl succeeded, but nwords might be invalid or buffer too small
+		nwords := int(req.Settings.LinkModeMasksNwords)
+		switch {
+		case nwords <= 0 || nwords > MAX_LINK_MODE_MASK_NWORDS:
+			// Sub-case 2a: Invalid nwords -> fallback
+			fmt.Printf("Warning: GLINKSETTINGS succeeded but returned invalid nwords (%d), attempting fallback to GSET\n", nwords)
+			attemptFallback = true
+			fallbackReason = "invalid nwords from GLINKSETTINGS"
+		case 3*nwords > len(req.Masks):
+			// Sub-case 2b: Buffer too small -> error
+			return nil, fmt.Errorf("kernel requires %d words for GLINKSETTINGS, buffer only has space for %d (max %d)", nwords, len(req.Masks)/3, MAX_LINK_MODE_MASK_NWORDS)
+		default:
+			// Sub-case 2c: Success (nwords valid and buffer sufficient)
+			results := &LinkSettings{
+				Speed:                req.Settings.Speed,
+				Duplex:               req.Settings.Duplex,
+				Port:                 req.Settings.Port,
+				PhyAddress:           req.Settings.PhyAddress,
+				Autoneg:              req.Settings.Autoneg,
+				MdixSupport:          req.Settings.MdixSupport,
+				EthTpMdix:            req.Settings.EthTpMdix,
+				EthTpMdixCtrl:        req.Settings.EthTpMdixCtrl,
+				Transceiver:          req.Settings.Transceiver,
+				MasterSlaveCfg:       req.Settings.MasterSlaveCfg,
+				MasterSlaveState:     req.Settings.MasterSlaveState,
+				SupportedLinkModes:   parseLinkModeMasks(req.Masks[0*nwords : 1*nwords]),
+				AdvertisingLinkModes: parseLinkModeMasks(req.Masks[1*nwords : 2*nwords]),
+				LpAdvertisingModes:   parseLinkModeMasks(req.Masks[2*nwords : 3*nwords]),
+				Source:               "GLINKSETTINGS",
+			}
+			if results.Speed == SPEED_UNKNOWN {
+				results.Speed = 0
+			}
+			return results, nil
+		}
+	} else if err != nil {
+		// Condition 3: ioctl failed with an error other than EOPNOTSUPP
+		// No fallback in this case.
+		return nil, fmt.Errorf("ETHTOOL_GLINKSETTINGS ioctl failed: %w", err)
+	}
+
+	// If we reach here, it means attemptFallback is true
+	if attemptFallback {
+		// Fallback to ETHTOOL_GSET using e.CmdGet
+		var cmd EthtoolCmd
+		_, errGet := e.CmdGet(&cmd, intf)
+		if errGet != nil {
+			return nil, fmt.Errorf("ETHTOOL_GLINKSETTINGS failed (%s), fallback ETHTOOL_GSET (CmdGet) also failed: %w", fallbackReason, errGet)
+		}
+		results := convertCmdToLinkSettings(&cmd)
+		results.Source = "GSET"
+		return results, nil
+	}
+
+	// Should be unreachable if logic is exhaustive
+	return nil, fmt.Errorf("unexpected state at end of GetLinkSettings")
+}
+
+// SetLinkSettings applies link settings, determining whether to use ETHTOOL_SLINKSETTINGS or ETHTOOL_SSET.
+func (e *Ethtool) SetLinkSettings(intf string, settings *LinkSettings) error {
+	var checkReq ethtoolLinkSettingsRequest
+	checkReq.Settings.Cmd = ETHTOOL_GLINKSETTINGS
+	checkReq.Settings.LinkModeMasksNwords = int8(MAX_LINK_MODE_MASK_NWORDS)
+
+	errGLinkSettings := e.ioctl(intf, uintptr(unsafe.Pointer(&checkReq)))
+	canUseGLinkSettings := false
+	nwords := 0
+
+	if errGLinkSettings == nil {
+		nwords = int(checkReq.Settings.LinkModeMasksNwords)
+		if nwords <= 0 || nwords > MAX_LINK_MODE_MASK_NWORDS {
+			return fmt.Errorf("ETHTOOL_GLINKSETTINGS check succeeded but returned invalid nwords: %d", nwords)
+		}
+		canUseGLinkSettings = true
+	} else if errno, ok := errGLinkSettings.(syscall.Errno); ok && errno == unix.EOPNOTSUPP {
+		canUseGLinkSettings = false
+	} else {
+		return fmt.Errorf("checking support via ETHTOOL_GLINKSETTINGS failed: %w", errGLinkSettings)
+	}
+
+	if canUseGLinkSettings {
+		var setReq ethtoolLinkSettingsRequest
+		if 3*nwords > len(setReq.Masks) {
+			return fmt.Errorf("internal error: required nwords (%d) exceeds allocated buffer (%d)", nwords, MAX_LINK_MODE_MASK_NWORDS)
+		}
+		setReq.Settings.Cmd = ETHTOOL_SLINKSETTINGS
+		setReq.Settings.Speed = settings.Speed
+		setReq.Settings.Duplex = settings.Duplex
+		setReq.Settings.Port = settings.Port
+		setReq.Settings.PhyAddress = settings.PhyAddress
+		setReq.Settings.Autoneg = settings.Autoneg
+		setReq.Settings.EthTpMdixCtrl = settings.EthTpMdixCtrl
+		setReq.Settings.MasterSlaveCfg = settings.MasterSlaveCfg
+		setReq.Settings.LinkModeMasksNwords = int8(nwords)
+
+		advertisingMask := buildLinkModeMask(settings.AdvertisingLinkModes, nwords)
+		if len(advertisingMask) != nwords {
+			return fmt.Errorf("failed to build advertising mask with correct size (%d != %d)", len(advertisingMask), nwords)
+		}
+		copy(setReq.Masks[nwords:2*nwords], advertisingMask)
+		zeroMaskSupported := make([]uint32, nwords)
+		zeroMaskLp := make([]uint32, nwords)
+		copy(setReq.Masks[0*nwords:1*nwords], zeroMaskSupported)
+		copy(setReq.Masks[2*nwords:3*nwords], zeroMaskLp)
+
+		if err := e.ioctl(intf, uintptr(unsafe.Pointer(&setReq))); err != nil {
+			return fmt.Errorf("ETHTOOL_SLINKSETTINGS ioctl failed: %w", err)
+		}
+		return nil
+
+	} else {
+		// Check if trying to set high bits when only SSET is available
+		advertisingMaskCheck := buildLinkModeMask(settings.AdvertisingLinkModes, MAX_LINK_MODE_MASK_NWORDS)
+		for i := 1; i < len(advertisingMaskCheck); i++ {
+			if advertisingMaskCheck[i] != 0 {
+				return fmt.Errorf("cannot set link modes beyond 32 bits using legacy ETHTOOL_SSET; device does not support ETHTOOL_SLINKSETTINGS")
+			}
+		}
+
+		// Fallback to SSET
+		cmd := convertLinkSettingsToCmd(settings)
+		_, errSet := e.CmdSet(cmd, intf)
+		if errSet != nil {
+			return fmt.Errorf("ETHTOOL_SLINKSETTINGS not supported, fallback ETHTOOL_SSET (CmdSet) failed: %w", errSet)
+		}
+		return nil
+	}
+}
+
+// parseLinkModeMasks converts a slice of uint32 bitmasks to a list of mode names.
+// It filters out non-speed/duplex modes (like TP, Autoneg, Pause).
+func parseLinkModeMasks(mask []uint32) []string {
+	modes := []string{}
+	for _, cap := range supportedCapabilities {
+		// Only include capabilities that represent a speed/duplex mode
+		if cap.speed > 0 {
+			bitIndex := int(cap.mask)
+			wordIndex := bitIndex / 32
+			bitInWord := uint(bitIndex % 32)
+			if wordIndex < len(mask) && (mask[wordIndex]>>(bitInWord))&1 != 0 {
+				modes = append(modes, cap.name)
+			}
+		}
+	}
+	return modes
+}
+
+// buildLinkModeMask converts a list of mode names back into a uint32 bitmask slice.
+// It filters out non-speed/duplex modes.
+func buildLinkModeMask(modes []string, nwords int) []uint32 {
+	if nwords <= 0 || nwords > MAX_LINK_MODE_MASK_NWORDS {
+		return make([]uint32, 0)
+	}
+	mask := make([]uint32, nwords)
+	modeMap := make(map[string]struct {
+		bitIndex int
+		speed    uint64
+	})
+	for _, cap := range supportedCapabilities {
+		// Only consider capabilities that represent a speed/duplex mode
+		if cap.speed > 0 {
+			modeMap[cap.name] = struct {
+				bitIndex int
+				speed    uint64
+			}{bitIndex: int(cap.mask), speed: cap.speed}
+		}
+	}
+	for _, modeName := range modes {
+		if info, ok := modeMap[strings.TrimSpace(modeName)]; ok {
+			wordIndex := info.bitIndex / 32
+			bitInWord := uint(info.bitIndex % 32)
+			if wordIndex < nwords {
+				mask[wordIndex] |= (1 << bitInWord)
+			} else {
+				fmt.Printf("Warning: Link mode '%s' (bit %d) exceeds device's mask size (%d words)\n", modeName, info.bitIndex, nwords)
+			}
+		} else {
+			// Check if the user provided a non-speed mode name - ignore it for the mask, maybe warn?
+			isKnownNonSpeed := false
+			for _, cap := range supportedCapabilities {
+				if cap.speed == 0 && cap.name == strings.TrimSpace(modeName) {
+					isKnownNonSpeed = true
+					break
+				}
+			}
+			if !isKnownNonSpeed {
+				fmt.Printf("Warning: Unknown link mode '%s' specified for mask building\n", modeName)
+			} // Silently ignore known non-speed modes like Autoneg, TP, Pause for the mask
+		}
+	}
+	return mask
+}
+
+// convertCmdToLinkSettings converts data from the legacy EthtoolCmd to the new LinkSettings format.
+func convertCmdToLinkSettings(cmd *EthtoolCmd) *LinkSettings {
+	ls := &LinkSettings{
+		Speed:                (uint32(cmd.Speed_hi) << 16) | uint32(cmd.Speed),
+		Duplex:               cmd.Duplex,
+		Port:                 cmd.Port,
+		PhyAddress:           cmd.Phy_address,
+		Autoneg:              cmd.Autoneg,
+		MdixSupport:          cmd.Mdio_support,
+		EthTpMdix:            cmd.Eth_tp_mdix,
+		EthTpMdixCtrl:        ETH_TP_MDI_INVALID,
+		Transceiver:          cmd.Transceiver,
+		MasterSlaveCfg:       0, // No equivalent in EthtoolCmd
+		MasterSlaveState:     0, // No equivalent in EthtoolCmd
+		SupportedLinkModes:   parseLegacyLinkModeMask(cmd.Supported),
+		AdvertisingLinkModes: parseLegacyLinkModeMask(cmd.Advertising),
+		LpAdvertisingModes:   parseLegacyLinkModeMask(cmd.Lp_advertising),
+	}
+	if cmd.Speed == math.MaxUint16 && cmd.Speed_hi == math.MaxUint16 {
+		ls.Speed = 0 // GSET uses 0xFFFF/0xFFFF for unknown/auto
+	} else if ls.Speed == SPEED_UNKNOWN {
+		ls.Speed = 0 // Also treat GLINKSETTINGS' unknown as 0 for consistency?
+	}
+	return ls
+}
+
+// parseLegacyLinkModeMask helper for converting single uint32 mask.
+func parseLegacyLinkModeMask(mask uint32) []string {
+	return parseLinkModeMasks([]uint32{mask})
+}
+
+// convertLinkSettingsToCmd converts new LinkSettings data back to the legacy EthtoolCmd format for SSET fallback.
+func convertLinkSettingsToCmd(ls *LinkSettings) *EthtoolCmd {
+	cmd := &EthtoolCmd{}
+	if ls.Speed == 0 || ls.Speed == SPEED_UNKNOWN {
+		cmd.Speed = math.MaxUint16
+		cmd.Speed_hi = math.MaxUint16
+	} else {
+		cmd.Speed = uint16(ls.Speed & 0xFFFF)
+		cmd.Speed_hi = uint16((ls.Speed >> 16) & 0xFFFF)
+	}
+	cmd.Duplex = ls.Duplex
+	cmd.Port = ls.Port
+	cmd.Phy_address = ls.PhyAddress
+	cmd.Autoneg = ls.Autoneg
+	// Cannot set EthTpMdixCtrl via EthtoolCmd
+	cmd.Transceiver = ls.Transceiver
+	cmd.Advertising = buildLegacyLinkModeMask(ls.AdvertisingLinkModes)
+	return cmd
+}
+
+// buildLegacyLinkModeMask helper for building single uint32 mask from names.
+func buildLegacyLinkModeMask(modes []string) uint32 {
+	maskSlice := buildLinkModeMask(modes, 1)
+	if len(maskSlice) > 0 {
+		return maskSlice[0]
+	}
+	return 0
+}

--- a/ethtool_link_settings_test.go
+++ b/ethtool_link_settings_test.go
@@ -1,0 +1,98 @@
+package ethtool
+
+import (
+	"net"
+	"reflect"
+	"sort"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestGetLinkSettings attempts to get link settings for all non-loopback interfaces.
+// This serves as a basic integration test to ensure the function handles
+// real ioctl calls, including potential fallbacks, without crashing.
+// Asserting specific values is difficult as capabilities vary widely between interfaces and drivers.
+func TestGetLinkSettings(t *testing.T) {
+	intfs, err := net.Interfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, intf := range intfs {
+		intfName := intf.Name
+		if intfName == "lo" {
+			continue
+		}
+		e, err := NewEthtool() // Assumes NewEthtool() correctly gets a socket fd
+		if err != nil {
+			// Log error for this interface but continue testing others
+			t.Errorf("Failed to create Ethtool instance for interface %s: %v", intfName, err)
+			continue
+		}
+		defer e.Close()
+
+		settings, err := e.GetLinkSettings(intfName)
+
+		// We expect either success (returning some data, possibly indicating 'unknown')
+		// or a specific error like EOPNOTSUPP if the interface/driver
+		// doesn't support either GLINKSETTINGS or GSET.
+		if err != nil {
+			if errno, ok := err.(syscall.Errno); ok {
+				if errno == unix.EOPNOTSUPP {
+					// This is an expected outcome for some interfaces/drivers
+					t.Logf("GetLinkSettings for '%s' returned EOPNOTSUPP (expected for some devices)", intfName)
+				} else {
+					// Report other unexpected errors
+					t.Errorf("GetLinkSettings for '%s' failed with unexpected error: %v", intfName, err)
+				}
+			} else {
+				// Non-syscall error
+				t.Errorf("GetLinkSettings for '%s' failed with non-syscall error: %v", intfName, err)
+			}
+		} else {
+			// If successful, check that the settings struct is not nil and Source is set
+			if settings == nil {
+				t.Errorf("GetLinkSettings for '%s' succeeded but returned nil settings", intfName)
+				// Cannot continue checks if settings is nil
+				continue
+			}
+			if settings.Source != "GLINKSETTINGS" && settings.Source != "GSET" {
+				t.Errorf("GetLinkSettings for '%s' succeeded but Source ('%s') is invalid", intfName, settings.Source)
+			}
+			t.Logf("GetLinkSettings for '%s' succeeded (Source: %s). Settings: %+v", intfName, settings.Source, settings)
+
+			// Check SupportedLinkModes
+			if settings.SupportedLinkModes == nil {
+				t.Errorf("GetLinkSettings for '%s' succeeded but SupportedLinkModes is nil", intfName)
+			} else {
+				t.Logf("Interface '%s' supported modes: %v", intfName, settings.SupportedLinkModes)
+			}
+
+			// If source was GSET, verify the conversion logic
+			if settings.Source == "GSET" {
+				var cmd EthtoolCmd
+				_, errGet := e.CmdGet(&cmd, intfName)
+				if errGet != nil {
+					t.Errorf("Failed to re-run CmdGet for '%s' to verify GSET conversion: %v", intfName, errGet)
+				} else {
+					expectedModes := parseLegacyLinkModeMask(cmd.Supported)
+					// Sort both slices for reliable comparison
+					sort.Strings(expectedModes)
+					actualModes := make([]string, len(settings.SupportedLinkModes))
+					copy(actualModes, settings.SupportedLinkModes)
+					sort.Strings(actualModes)
+
+					if !reflect.DeepEqual(actualModes, expectedModes) {
+						t.Errorf("SupportedLinkModes mismatch for '%s' (Source: GSET). Got %v, expected %v (from raw CmdGet)", intfName, actualModes, expectedModes)
+					}
+				}
+			}
+
+			// Basic sanity checks if it succeeded (values might be 0 or unknown)
+			if settings.Speed == SPEED_UNKNOWN { // SPEED_UNKNOWN defined in ethtool.go
+				t.Logf("Interface '%s' reported speed as SPEED_UNKNOWN (0x%x)", intfName, SPEED_UNKNOWN)
+			}
+		}
+	}
+}

--- a/ethtool_linux.go
+++ b/ethtool_linux.go
@@ -25,32 +25,106 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// Updated supportedCapabilities including modes from ethtool.h enum ethtool_link_mode_bit_indices
 var supportedCapabilities = []struct {
 	name  string
-	mask  uint64
-	speed uint64
+	mask  uint64 // Use uint64 to accommodate indices > 31
+	speed uint64 // Speed in bps, 0 for non-speed modes
 }{
-	{"10baseT_Half", unix.ETHTOOL_LINK_MODE_10baseT_Half_BIT, 10_000_000},
-	{"10baseT_Full", unix.ETHTOOL_LINK_MODE_10baseT_Full_BIT, 10_000_000},
-	{"100baseT_Half", unix.ETHTOOL_LINK_MODE_100baseT_Half_BIT, 100_000_000},
-	{"100baseT_Full", unix.ETHTOOL_LINK_MODE_100baseT_Full_BIT, 100_000_000},
-	{"1000baseT_Half", unix.ETHTOOL_LINK_MODE_1000baseT_Half_BIT, 1_000_000_000},
-	{"1000baseT_Full", unix.ETHTOOL_LINK_MODE_1000baseT_Full_BIT, 1_000_000_000},
-	{"10000baseT_Full", unix.ETHTOOL_LINK_MODE_10000baseT_Full_BIT, 10_000_000_000},
-	{"2500baseT_Full", unix.ETHTOOL_LINK_MODE_2500baseT_Full_BIT, 2_500_000_000},
-	{"1000baseKX_Full", unix.ETHTOOL_LINK_MODE_1000baseKX_Full_BIT, 1_000_000_000},
-	{"10000baseKX_Full", unix.ETHTOOL_LINK_MODE_10000baseKX4_Full_BIT, 10_000_000_000},
-	{"10000baseKR_Full", unix.ETHTOOL_LINK_MODE_10000baseKR_Full_BIT, 10_000_000_000},
-	{"10000baseR_FEC", unix.ETHTOOL_LINK_MODE_10000baseR_FEC_BIT, 10_000_000_000},
-	{"20000baseMLD2_Full", unix.ETHTOOL_LINK_MODE_20000baseMLD2_Full_BIT, 20_000_000_000},
-	{"20000baseKR2_Full", unix.ETHTOOL_LINK_MODE_20000baseKR2_Full_BIT, 20_000_000_000},
-	{"40000baseKR4_Full", unix.ETHTOOL_LINK_MODE_40000baseKR4_Full_BIT, 40_000_000_000},
-	{"40000baseCR4_Full", unix.ETHTOOL_LINK_MODE_40000baseCR4_Full_BIT, 40_000_000_000},
-	{"40000baseSR4_Full", unix.ETHTOOL_LINK_MODE_40000baseSR4_Full_BIT, 40_000_000_000},
-	{"40000baseLR4_Full", unix.ETHTOOL_LINK_MODE_40000baseLR4_Full_BIT, 40_000_000_000},
-	{"56000baseKR4_Full", unix.ETHTOOL_LINK_MODE_56000baseKR4_Full_BIT, 56_000_000_000},
-	{"56000baseCR4_Full", unix.ETHTOOL_LINK_MODE_56000baseCR4_Full_BIT, 56_000_000_000},
-	{"56000baseSR4_Full", unix.ETHTOOL_LINK_MODE_56000baseSR4_Full_BIT, 56_000_000_000},
-	{"56000baseLR4_Full", unix.ETHTOOL_LINK_MODE_56000baseLR4_Full_BIT, 56_000_000_000},
-	{"25000baseCR_Full", unix.ETHTOOL_LINK_MODE_25000baseCR_Full_BIT, 25_000_000_000},
+	// Existing entries (reordered slightly by bit index for clarity)
+	{"10baseT_Half", unix.ETHTOOL_LINK_MODE_10baseT_Half_BIT, 10_000_000},        // 0
+	{"10baseT_Full", unix.ETHTOOL_LINK_MODE_10baseT_Full_BIT, 10_000_000},        // 1
+	{"100baseT_Half", unix.ETHTOOL_LINK_MODE_100baseT_Half_BIT, 100_000_000},     // 2
+	{"100baseT_Full", unix.ETHTOOL_LINK_MODE_100baseT_Full_BIT, 100_000_000},     // 3
+	{"1000baseT_Half", unix.ETHTOOL_LINK_MODE_1000baseT_Half_BIT, 1_000_000_000}, // 4
+	{"1000baseT_Full", unix.ETHTOOL_LINK_MODE_1000baseT_Full_BIT, 1_000_000_000}, // 5
+	// Newly added or re-confirmed based on full enum
+	{"Autoneg", unix.ETHTOOL_LINK_MODE_Autoneg_BIT, 0},                                    // 6
+	{"TP", unix.ETHTOOL_LINK_MODE_TP_BIT, 0},                                              // 7 (Twisted Pair port)
+	{"AUI", unix.ETHTOOL_LINK_MODE_AUI_BIT, 0},                                            // 8 (AUI port)
+	{"MII", unix.ETHTOOL_LINK_MODE_MII_BIT, 0},                                            // 9 (MII port)
+	{"FIBRE", unix.ETHTOOL_LINK_MODE_FIBRE_BIT, 0},                                        // 10 (FIBRE port)
+	{"BNC", unix.ETHTOOL_LINK_MODE_BNC_BIT, 0},                                            // 11 (BNC port)
+	{"10000baseT_Full", unix.ETHTOOL_LINK_MODE_10000baseT_Full_BIT, 10_000_000_000},       // 12
+	{"Pause", unix.ETHTOOL_LINK_MODE_Pause_BIT, 0},                                        // 13
+	{"Asym_Pause", unix.ETHTOOL_LINK_MODE_Asym_Pause_BIT, 0},                              // 14
+	{"2500baseX_Full", unix.ETHTOOL_LINK_MODE_2500baseX_Full_BIT, 2_500_000_000},          // 15
+	{"Backplane", unix.ETHTOOL_LINK_MODE_Backplane_BIT, 0},                                // 16 (Backplane port)
+	{"1000baseKX_Full", unix.ETHTOOL_LINK_MODE_1000baseKX_Full_BIT, 1_000_000_000},        // 17
+	{"10000baseKX4_Full", unix.ETHTOOL_LINK_MODE_10000baseKX4_Full_BIT, 10_000_000_000},   // 18
+	{"10000baseKR_Full", unix.ETHTOOL_LINK_MODE_10000baseKR_Full_BIT, 10_000_000_000},     // 19
+	{"10000baseR_FEC", unix.ETHTOOL_LINK_MODE_10000baseR_FEC_BIT, 10_000_000_000},         // 20
+	{"20000baseMLD2_Full", unix.ETHTOOL_LINK_MODE_20000baseMLD2_Full_BIT, 20_000_000_000}, // 21
+	{"20000baseKR2_Full", unix.ETHTOOL_LINK_MODE_20000baseKR2_Full_BIT, 20_000_000_000},   // 22
+	{"40000baseKR4_Full", unix.ETHTOOL_LINK_MODE_40000baseKR4_Full_BIT, 40_000_000_000},   // 23
+	{"40000baseCR4_Full", unix.ETHTOOL_LINK_MODE_40000baseCR4_Full_BIT, 40_000_000_000},   // 24
+	{"40000baseSR4_Full", unix.ETHTOOL_LINK_MODE_40000baseSR4_Full_BIT, 40_000_000_000},   // 25
+	{"40000baseLR4_Full", unix.ETHTOOL_LINK_MODE_40000baseLR4_Full_BIT, 40_000_000_000},   // 26
+	{"56000baseKR4_Full", unix.ETHTOOL_LINK_MODE_56000baseKR4_Full_BIT, 56_000_000_000},   // 27
+	{"56000baseCR4_Full", unix.ETHTOOL_LINK_MODE_56000baseCR4_Full_BIT, 56_000_000_000},   // 28
+	{"56000baseSR4_Full", unix.ETHTOOL_LINK_MODE_56000baseSR4_Full_BIT, 56_000_000_000},   // 29
+	{"56000baseLR4_Full", unix.ETHTOOL_LINK_MODE_56000baseLR4_Full_BIT, 56_000_000_000},   // 30
+	{"25000baseCR_Full", unix.ETHTOOL_LINK_MODE_25000baseCR_Full_BIT, 25_000_000_000},     // 31
+	// Modes beyond bit 31 (require GLINKSETTINGS)
+	{"25000baseKR_Full", unix.ETHTOOL_LINK_MODE_25000baseKR_Full_BIT, 25_000_000_000},                      // 32
+	{"25000baseSR_Full", unix.ETHTOOL_LINK_MODE_25000baseSR_Full_BIT, 25_000_000_000},                      // 33
+	{"50000baseCR2_Full", unix.ETHTOOL_LINK_MODE_50000baseCR2_Full_BIT, 50_000_000_000},                    // 34
+	{"50000baseKR2_Full", unix.ETHTOOL_LINK_MODE_50000baseKR2_Full_BIT, 50_000_000_000},                    // 35
+	{"100000baseKR4_Full", unix.ETHTOOL_LINK_MODE_100000baseKR4_Full_BIT, 100_000_000_000},                 // 36
+	{"100000baseSR4_Full", unix.ETHTOOL_LINK_MODE_100000baseSR4_Full_BIT, 100_000_000_000},                 // 37
+	{"100000baseCR4_Full", unix.ETHTOOL_LINK_MODE_100000baseCR4_Full_BIT, 100_000_000_000},                 // 38
+	{"100000baseLR4_ER4_Full", unix.ETHTOOL_LINK_MODE_100000baseLR4_ER4_Full_BIT, 100_000_000_000},         // 39
+	{"50000baseSR2_Full", unix.ETHTOOL_LINK_MODE_50000baseSR2_Full_BIT, 50_000_000_000},                    // 40
+	{"1000baseX_Full", unix.ETHTOOL_LINK_MODE_1000baseX_Full_BIT, 1_000_000_000},                           // 41
+	{"10000baseCR_Full", unix.ETHTOOL_LINK_MODE_10000baseCR_Full_BIT, 10_000_000_000},                      // 42
+	{"10000baseSR_Full", unix.ETHTOOL_LINK_MODE_10000baseSR_Full_BIT, 10_000_000_000},                      // 43
+	{"10000baseLR_Full", unix.ETHTOOL_LINK_MODE_10000baseLR_Full_BIT, 10_000_000_000},                      // 44
+	{"10000baseLRM_Full", unix.ETHTOOL_LINK_MODE_10000baseLRM_Full_BIT, 10_000_000_000},                    // 45
+	{"10000baseER_Full", unix.ETHTOOL_LINK_MODE_10000baseER_Full_BIT, 10_000_000_000},                      // 46
+	{"2500baseT_Full", unix.ETHTOOL_LINK_MODE_2500baseT_Full_BIT, 2_500_000_000},                           // 47 (already present but reconfirmed)
+	{"5000baseT_Full", unix.ETHTOOL_LINK_MODE_5000baseT_Full_BIT, 5_000_000_000},                           // 48
+	{"FEC_NONE", unix.ETHTOOL_LINK_MODE_FEC_NONE_BIT, 0},                                                   // 49
+	{"FEC_RS", unix.ETHTOOL_LINK_MODE_FEC_RS_BIT, 0},                                                       // 50 (Reed-Solomon FEC)
+	{"FEC_BASER", unix.ETHTOOL_LINK_MODE_FEC_BASER_BIT, 0},                                                 // 51 (BaseR FEC)
+	{"50000baseKR_Full", unix.ETHTOOL_LINK_MODE_50000baseKR_Full_BIT, 50_000_000_000},                      // 52
+	{"50000baseSR_Full", unix.ETHTOOL_LINK_MODE_50000baseSR_Full_BIT, 50_000_000_000},                      // 53
+	{"50000baseCR_Full", unix.ETHTOOL_LINK_MODE_50000baseCR_Full_BIT, 50_000_000_000},                      // 54
+	{"50000baseLR_ER_FR_Full", unix.ETHTOOL_LINK_MODE_50000baseLR_ER_FR_Full_BIT, 50_000_000_000},          // 55
+	{"50000baseDR_Full", unix.ETHTOOL_LINK_MODE_50000baseDR_Full_BIT, 50_000_000_000},                      // 56
+	{"100000baseKR2_Full", unix.ETHTOOL_LINK_MODE_100000baseKR2_Full_BIT, 100_000_000_000},                 // 57
+	{"100000baseSR2_Full", unix.ETHTOOL_LINK_MODE_100000baseSR2_Full_BIT, 100_000_000_000},                 // 58
+	{"100000baseCR2_Full", unix.ETHTOOL_LINK_MODE_100000baseCR2_Full_BIT, 100_000_000_000},                 // 59
+	{"100000baseLR2_ER2_FR2_Full", unix.ETHTOOL_LINK_MODE_100000baseLR2_ER2_FR2_Full_BIT, 100_000_000_000}, // 60
+	{"100000baseDR2_Full", unix.ETHTOOL_LINK_MODE_100000baseDR2_Full_BIT, 100_000_000_000},                 // 61
+	{"200000baseKR4_Full", unix.ETHTOOL_LINK_MODE_200000baseKR4_Full_BIT, 200_000_000_000},                 // 62
+	{"200000baseSR4_Full", unix.ETHTOOL_LINK_MODE_200000baseSR4_Full_BIT, 200_000_000_000},                 // 63
+	{"200000baseLR4_ER4_FR4_Full", unix.ETHTOOL_LINK_MODE_200000baseLR4_ER4_FR4_Full_BIT, 200_000_000_000}, // 64
+	{"200000baseDR4_Full", unix.ETHTOOL_LINK_MODE_200000baseDR4_Full_BIT, 200_000_000_000},                 // 65
+	{"200000baseCR4_Full", unix.ETHTOOL_LINK_MODE_200000baseCR4_Full_BIT, 200_000_000_000},                 // 66
+	{"100baseT1_Full", unix.ETHTOOL_LINK_MODE_100baseT1_Full_BIT, 100_000_000},                             // 67 (Automotive/SPE)
+	{"1000baseT1_Full", unix.ETHTOOL_LINK_MODE_1000baseT1_Full_BIT, 1_000_000_000},                         // 68 (Automotive/SPE)
+	{"400000baseKR8_Full", unix.ETHTOOL_LINK_MODE_400000baseKR8_Full_BIT, 400_000_000_000},                 // 69
+	{"400000baseSR8_Full", unix.ETHTOOL_LINK_MODE_400000baseSR8_Full_BIT, 400_000_000_000},                 // 70
+	{"400000baseLR8_ER8_FR8_Full", unix.ETHTOOL_LINK_MODE_400000baseLR8_ER8_FR8_Full_BIT, 400_000_000_000}, // 71
+	{"400000baseDR8_Full", unix.ETHTOOL_LINK_MODE_400000baseDR8_Full_BIT, 400_000_000_000},                 // 72
+	{"400000baseCR8_Full", unix.ETHTOOL_LINK_MODE_400000baseCR8_Full_BIT, 400_000_000_000},                 // 73
+	{"FEC_LLRS", unix.ETHTOOL_LINK_MODE_FEC_LLRS_BIT, 0},                                                   // 74 (Low Latency Reed-Solomon FEC)
+	// PAM4 modes start here? Often indicated by lack of KR/CR/SR/LR or different naming
+	{"100000baseKR_Full", unix.ETHTOOL_LINK_MODE_100000baseKR_Full_BIT, 100_000_000_000},                   // 75 (Likely 100GBASE-KR1)
+	{"100000baseSR_Full", unix.ETHTOOL_LINK_MODE_100000baseSR_Full_BIT, 100_000_000_000},                   // 76 (Likely 100GBASE-SR1)
+	{"100000baseLR_ER_FR_Full", unix.ETHTOOL_LINK_MODE_100000baseLR_ER_FR_Full_BIT, 100_000_000_000},       // 77 (Likely 100GBASE-LR1/ER1/FR1)
+	{"100000baseCR_Full", unix.ETHTOOL_LINK_MODE_100000baseCR_Full_BIT, 100_000_000_000},                   // 78 (Likely 100GBASE-CR1)
+	{"100000baseDR_Full", unix.ETHTOOL_LINK_MODE_100000baseDR_Full_BIT, 100_000_000_000},                   // 79
+	{"200000baseKR2_Full", unix.ETHTOOL_LINK_MODE_200000baseKR2_Full_BIT, 200_000_000_000},                 // 80 (Likely 200GBASE-KR2)
+	{"200000baseSR2_Full", unix.ETHTOOL_LINK_MODE_200000baseSR2_Full_BIT, 200_000_000_000},                 // 81 (Likely 200GBASE-SR2)
+	{"200000baseLR2_ER2_FR2_Full", unix.ETHTOOL_LINK_MODE_200000baseLR2_ER2_FR2_Full_BIT, 200_000_000_000}, // 82 (Likely 200GBASE-LR2/etc)
+	{"200000baseDR2_Full", unix.ETHTOOL_LINK_MODE_200000baseDR2_Full_BIT, 200_000_000_000},                 // 83
+	{"200000baseCR2_Full", unix.ETHTOOL_LINK_MODE_200000baseCR2_Full_BIT, 200_000_000_000},                 // 84 (Likely 200GBASE-CR2)
+	{"400000baseKR4_Full", unix.ETHTOOL_LINK_MODE_400000baseKR4_Full_BIT, 400_000_000_000},                 // 85 (Likely 400GBASE-KR4)
+	{"400000baseSR4_Full", unix.ETHTOOL_LINK_MODE_400000baseSR4_Full_BIT, 400_000_000_000},                 // 86 (Likely 400GBASE-SR4)
+	{"400000baseLR4_ER4_FR4_Full", unix.ETHTOOL_LINK_MODE_400000baseLR4_ER4_FR4_Full_BIT, 400_000_000_000}, // 87 (Likely 400GBASE-LR4/etc)
+	{"400000baseDR4_Full", unix.ETHTOOL_LINK_MODE_400000baseDR4_Full_BIT, 400_000_000_000},                 // 88
+	{"400000baseCR4_Full", unix.ETHTOOL_LINK_MODE_400000baseCR4_Full_BIT, 400_000_000_000},                 // 89 (Likely 400GBASE-CR4)
+	{"100baseFX_Half", unix.ETHTOOL_LINK_MODE_100baseFX_Half_BIT, 100_000_000},                             // 90
+	{"100baseFX_Full", unix.ETHTOOL_LINK_MODE_100baseFX_Full_BIT, 100_000_000},                             // 91
 }

--- a/example/main.go
+++ b/example/main.go
@@ -82,4 +82,10 @@ func main() {
 		panic(err.Error())
 	}
 	fmt.Printf("module eeprom: %+v\n", eeprom)
+
+	linkSettings, err := e.GetLinkSettings(*name)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("link settings: %+v\n", linkSettings)
 }


### PR DESCRIPTION
fix #82 #33

## Added Link Settings (GLINKSETTINGS/SLINKSETTINGS) Support

This change introduces support for the `ETHTOOL_GLINKSETTINGS` and `ETHTOOL_SLINKSETTINGS` ioctls, providing a more modern and comprehensive way to configure network interface Link Settings compared to the older `ETHTOOL_GSET`/`SSET`.

### Main Functions

*   **`GetLinkSettings(intfName string) (*LinkSettings, error)`**:
    *   Retrieves the Link Settings for the specified network interface (`intfName`).
    *   **Attempts first** to use the `ETHTOOL_GLINKSETTINGS` ioctl to get extended Link Settings.
    *   If the kernel or driver does not support `GLINKSETTINGS` (returns an `EOPNOTSUPP` error), it **automatically falls back** to calling the older `CmdGet()` (using `ETHTOOL_GSET`) and converts the result to the new `LinkSettings` struct before returning.
    *   Returns a pointer to a `LinkSettings` struct containing the detailed Link Settings.

*   **`SetLinkSettings(intfName string, settings LinkSettings) error`**:
    *   Sets the Link Settings for the specified network interface (`intfName`) using the provided `settings` struct.
    *   **First checks** if the device supports the `GLINKSETTINGS` interface.
    *   If supported, it uses the `ETHTOOL_SLINKSETTINGS` ioctl to apply the settings.
    *   If not supported (returns an `EOPNOTSUPP` error), it **attempts to fall back** to calling the older `CmdSet()` (using `ETHTOOL_SSET`).
    *   **Important**: When falling back to `SSET`, it checks if the requested Link Modes in `settings` exceed the capabilities of the old interface (e.g., setting modes beyond bit 31). If they do, an error is returned because the old interface cannot fulfill the request.

