### PR TITLE
optimize large slice alloc in Stats

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -29,7 +29,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"strings"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -107,6 +107,23 @@ const (
 
 const (
 	DEFAULT_BLINK_DURATION = 60 * time.Second
+)
+
+var (
+	gstringsPool = sync.Pool{
+		New: func() interface{} {
+			// new() will allocate and zero-initialize the struct.
+			// The large data array within ethtoolGStrings will be zeroed.
+			return new(ethtoolGStrings)
+		},
+	}
+	statsPool = sync.Pool{
+		New: func() interface{} {
+			// new() will allocate and zero-initialize the struct.
+			// The large data array within ethtoolStats will be zeroed.
+			return new(ethtoolStats)
+		},
+	}
 )
 
 type ifreq struct {
@@ -1125,41 +1142,43 @@ func (e *Ethtool) Stats(intf string) (map[string]uint64, error) {
 		return nil, err
 	}
 
-	if drvinfo.n_stats*ETH_GSTRING_LEN > MAX_GSTRINGS*ETH_GSTRING_LEN {
+	if drvinfo.n_stats > MAX_GSTRINGS {
 		return nil, fmt.Errorf("ethtool currently doesn't support more than %d entries, received %d", MAX_GSTRINGS, drvinfo.n_stats)
 	}
 
-	gstrings := ethtoolGStrings{
-		cmd:        ETHTOOL_GSTRINGS,
-		string_set: ETH_SS_STATS,
-		len:        drvinfo.n_stats,
-		data:       [MAX_GSTRINGS * ETH_GSTRING_LEN]byte{},
-	}
+	gstringsPtr := gstringsPool.Get().(*ethtoolGStrings)
+	defer gstringsPool.Put(gstringsPtr)
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&gstrings))); err != nil {
+	gstringsPtr.cmd = ETHTOOL_GSTRINGS
+	gstringsPtr.string_set = ETH_SS_STATS
+	gstringsPtr.len = drvinfo.n_stats
+
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(gstringsPtr))); err != nil {
 		return nil, err
 	}
 
-	stats := ethtoolStats{
-		cmd:     ETHTOOL_GSTATS,
-		n_stats: drvinfo.n_stats,
-		data:    [MAX_GSTRINGS]uint64{},
-	}
+	statsPtr := statsPool.Get().(*ethtoolStats)
+	defer statsPool.Put(statsPtr)
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&stats))); err != nil {
+	statsPtr.cmd = ETHTOOL_GSTATS
+	statsPtr.n_stats = drvinfo.n_stats
+
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(statsPtr))); err != nil {
 		return nil, err
 	}
 
-	result := make(map[string]uint64)
+	result := make(map[string]uint64, drvinfo.n_stats)
 	for i := 0; i != int(drvinfo.n_stats); i++ {
-		b := gstrings.data[i*ETH_GSTRING_LEN : i*ETH_GSTRING_LEN+ETH_GSTRING_LEN]
-		strEnd := strings.Index(string(b), "\x00")
+		b := gstringsPtr.data[i*ETH_GSTRING_LEN : (i+1)*ETH_GSTRING_LEN]
+
+		strEnd := bytes.IndexByte(b, 0)
 		if strEnd == -1 {
 			strEnd = ETH_GSTRING_LEN
 		}
 		key := string(b[:strEnd])
+
 		if len(key) != 0 {
-			result[key] = stats.data[i]
+			result[key] = statsPtr.data[i]
 		}
 	}
 

--- a/ethtool_test.go
+++ b/ethtool_test.go
@@ -189,3 +189,23 @@ func TestIdentity(t *testing.T) {
 		t.Fatal("Unable to identity any interface of this system.")
 	}
 }
+
+func BenchmarkStats(b *testing.B) {
+	intfs, err := net.Interfaces()
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, intf := range intfs {
+		if intf.Name == "lo" {
+			continue
+		}
+		b.Run(intf.Name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := Stats(intf.Name)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix #104

Introduce sync pool to optimize large object allocation

```
$ benchstat bench.out.master bench.out.perf
goos: linux
goarch: amd64
pkg: github.com/safchain/ethtool
cpu: Intel(R) Core(TM) i7-1065G7 CPU @ 1.30GHz
               │ bench.out.master │            bench.out.perf            │
               │      sec/op      │    sec/op     vs base                │
Stats/enp0s3-4       789.0µ ± 11%   398.5µ ± 14%  -49.49% (p=0.002 n=10)
Stats/enp0s8-4       777.9µ ±  8%   373.7µ ±  7%  -51.96% (p=0.000 n=10)
geomean              783.4µ         385.9µ        -50.74%

               │ bench.out.master │            bench.out.perf             │
               │       B/op       │     B/op       vs base                │
Stats/enp0s3-4    1300.243Ki ± 0%   3.576Ki ± 30%  -99.72% (p=0.000 n=10)
Stats/enp0s8-4    1300.238Ki ± 0%   3.896Ki ± 11%  -99.70% (p=0.000 n=10)
geomean              1.270Mi        3.732Ki        -99.71%

               │ bench.out.master │           bench.out.perf           │
               │    allocs/op     │ allocs/op   vs base                │
Stats/enp0s3-4         59.00 ± 0%   51.00 ± 0%  -13.56% (p=0.000 n=10)
Stats/enp0s8-4         59.00 ± 0%   51.00 ± 0%  -13.56% (p=0.000 n=10)
geomean                59.00        51.00       -13.56%
```