### PR TITLE
Improve Go compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@
 
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
   - package-ecosystem: gomod
     directory: /
     schedule:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,11 +16,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
-          go-version: stable
+          go-version: '1.24.x'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
         with:
-          version: v2.0
+          version: v2.2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -4,16 +4,21 @@ on: [push, pull_request]
 jobs:
   unittests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - '1.23.x'
+          - '1.24.x'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
-          go-version: '1.24.2'
+          go-version: ${{ matrix.go }}
 
-      - uses: ibiqlik/action-yamllint@v3
+      - uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  # v3.1.1
         with:
           format: auto
 

--- a/.yamllint
+++ b/.yamllint
@@ -3,5 +3,6 @@ extends: default
 
 rules:
   document-start: disable
+  line-length: disable
   truthy:
     check-keys: false

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/safchain/ethtool
 
-go 1.24.2
+go 1.23.0
 
-require golang.org/x/sys v0.33.0
+require golang.org/x/sys v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
-golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
+golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
The upstream Go support policy is to support the latest two major versions of Go. Update the `go` directive that specifies the minimum Go version required to support Go 1.23.x.
* Pin GitHub actions for supply chain security.
* Add matrix test for current Go versions.
* Bump golangci-lint version.