### PR TITLE
Fix dangling uintptr bugs

### DIFF
--- a/ethtool.go
+++ b/ethtool.go
@@ -162,7 +162,9 @@ var (
 
 type ifreq struct {
 	ifr_name [IFNAMSIZ]byte
-	ifr_data uintptr
+	// unsafe.Pointer is not opaque to the runtime and
+	// will be updated if the underlying object moves.
+	ifr_data unsafe.Pointer
 }
 
 // following structures comes from uapi/linux/ethtool.h
@@ -650,7 +652,7 @@ func (e *Ethtool) GetWakeOnLan(intf string) (WakeOnLan, error) {
 		Cmd: ETHTOOL_GWOL,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&wol))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&wol)); err != nil {
 		return WakeOnLan{}, err
 	}
 
@@ -662,14 +664,14 @@ func (e *Ethtool) GetWakeOnLan(intf string) (WakeOnLan, error) {
 func (e *Ethtool) SetWakeOnLan(intf string, wol WakeOnLan) (WakeOnLan, error) {
 	wol.Cmd = ETHTOOL_SWOL
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&wol))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&wol)); err != nil {
 		return WakeOnLan{}, err
 	}
 
 	return wol, nil
 }
 
-func (e *Ethtool) ioctl(intf string, data uintptr) error {
+func (e *Ethtool) ioctl(intf string, data unsafe.Pointer) error {
 	var name [IFNAMSIZ]byte
 	copy(name[:], []byte(intf))
 
@@ -691,7 +693,7 @@ func (e *Ethtool) getDriverInfo(intf string) (ethtoolDrvInfo, error) {
 		cmd: ETHTOOL_GDRVINFO,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&drvinfo))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&drvinfo)); err != nil {
 		return ethtoolDrvInfo{}, err
 	}
 
@@ -705,7 +707,7 @@ func (e *Ethtool) getIndir(intf string) (Indir, error) {
 		Size: 0,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&indir_head))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&indir_head)); err != nil {
 		return Indir{}, err
 	}
 
@@ -714,7 +716,7 @@ func (e *Ethtool) getIndir(intf string) (Indir, error) {
 		Size: indir_head.Size,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&indir))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&indir)); err != nil {
 		return Indir{}, err
 	}
 
@@ -735,7 +737,7 @@ func (e *Ethtool) setIndir(intf string, indir Indir, setIndir SetIndir) (Indir, 
 	}
 
 	indir.Cmd = ETHTOOL_SRXFHINDIR
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&indir))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&indir)); err != nil {
 		return Indir{}, err
 	}
 
@@ -789,7 +791,7 @@ func (e *Ethtool) getChannels(intf string) (Channels, error) {
 		Cmd: ETHTOOL_GCHANNELS,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&channels))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&channels)); err != nil {
 		return Channels{}, err
 	}
 
@@ -799,7 +801,7 @@ func (e *Ethtool) getChannels(intf string) (Channels, error) {
 func (e *Ethtool) setChannels(intf string, channels Channels) (Channels, error) {
 	channels.Cmd = ETHTOOL_SCHANNELS
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&channels))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&channels)); err != nil {
 		return Channels{}, err
 	}
 
@@ -811,7 +813,7 @@ func (e *Ethtool) getCoalesce(intf string) (Coalesce, error) {
 		Cmd: ETHTOOL_GCOALESCE,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&coalesce))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&coalesce)); err != nil {
 		return Coalesce{}, err
 	}
 
@@ -821,7 +823,7 @@ func (e *Ethtool) getCoalesce(intf string) (Coalesce, error) {
 func (e *Ethtool) setCoalesce(intf string, coalesce Coalesce) (Coalesce, error) {
 	coalesce.Cmd = ETHTOOL_SCOALESCE
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&coalesce))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&coalesce)); err != nil {
 		return Coalesce{}, err
 	}
 
@@ -833,7 +835,7 @@ func (e *Ethtool) getTimestampingInformation(intf string) (TimestampingInformati
 		Cmd: ETHTOOL_GET_TS_INFO,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&ts))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&ts)); err != nil {
 		return TimestampingInformation{}, err
 	}
 
@@ -846,7 +848,7 @@ func (e *Ethtool) getPermAddr(intf string) (ethtoolPermAddr, error) {
 		size: PERMADDR_LEN,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&permAddr))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&permAddr)); err != nil {
 		return ethtoolPermAddr{}, err
 	}
 
@@ -858,7 +860,7 @@ func (e *Ethtool) getModuleEeprom(intf string) (ethtoolEeprom, ethtoolModInfo, e
 		cmd: ETHTOOL_GMODULEINFO,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&modInfo))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&modInfo)); err != nil {
 		return ethtoolEeprom{}, ethtoolModInfo{}, err
 	}
 
@@ -872,7 +874,7 @@ func (e *Ethtool) getModuleEeprom(intf string) (ethtoolEeprom, ethtoolModInfo, e
 		return ethtoolEeprom{}, ethtoolModInfo{}, fmt.Errorf("eeprom size: %d is larger than buffer size: %d", modInfo.eeprom_len, EEPROM_LEN)
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&eeprom))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&eeprom)); err != nil {
 		return ethtoolEeprom{}, ethtoolModInfo{}, err
 	}
 
@@ -885,7 +887,7 @@ func (e *Ethtool) GetRing(intf string) (Ring, error) {
 		Cmd: ETHTOOL_GRINGPARAM,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&ring))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&ring)); err != nil {
 		return Ring{}, err
 	}
 
@@ -896,7 +898,7 @@ func (e *Ethtool) GetRing(intf string) (Ring, error) {
 func (e *Ethtool) SetRing(intf string, ring Ring) (Ring, error) {
 	ring.Cmd = ETHTOOL_SRINGPARAM
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&ring))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&ring)); err != nil {
 		return Ring{}, err
 	}
 
@@ -909,7 +911,7 @@ func (e *Ethtool) GetPause(intf string) (Pause, error) {
 		Cmd: ETHTOOL_GPAUSEPARAM,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&pause))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&pause)); err != nil {
 		return Pause{}, err
 	}
 
@@ -920,7 +922,7 @@ func (e *Ethtool) GetPause(intf string) (Pause, error) {
 func (e *Ethtool) SetPause(intf string, pause Pause) (Pause, error) {
 	pause.Cmd = ETHTOOL_SPAUSEPARAM
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&pause))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&pause)); err != nil {
 		return Pause{}, err
 	}
 
@@ -967,7 +969,7 @@ func (e *Ethtool) getNames(intf string, mask int) (map[string]uint, error) {
 		data:      [MAX_SSET_INFO]uint32{},
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&ssetInfo))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&ssetInfo)); err != nil {
 		return nil, err
 	}
 
@@ -986,7 +988,7 @@ func (e *Ethtool) getNames(intf string, mask int) (map[string]uint, error) {
 		data:       [MAX_GSTRINGS * ETH_GSTRING_LEN]byte{},
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&gstrings))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&gstrings)); err != nil {
 		return nil, err
 	}
 
@@ -1024,7 +1026,7 @@ func (e *Ethtool) Features(intf string) (map[string]bool, error) {
 		size: (length + 32 - 1) / 32,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&features))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&features)); err != nil {
 		return nil, err
 	}
 
@@ -1054,7 +1056,7 @@ func (e *Ethtool) FeaturesWithState(intf string) (map[string]FeatureState, error
 		size: (length + 32 - 1) / 32,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&features))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&features)); err != nil {
 		return nil, err
 	}
 
@@ -1088,7 +1090,7 @@ func (e *Ethtool) Change(intf string, config map[string]bool) error {
 		}
 	}
 
-	return e.ioctl(intf, uintptr(unsafe.Pointer(&features)))
+	return e.ioctl(intf, unsafe.Pointer(&features))
 }
 
 // PrivFlagsNames shows supported private flags by their name.
@@ -1110,7 +1112,7 @@ func (e *Ethtool) PrivFlags(intf string) (map[string]bool, error) {
 
 	var val ethtoolLink
 	val.cmd = ETHTOOL_GPFLAGS
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&val))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&val)); err != nil {
 		return nil, err
 	}
 
@@ -1131,7 +1133,7 @@ func (e *Ethtool) UpdatePrivFlags(intf string, config map[string]bool) error {
 
 	var curr ethtoolLink
 	curr.cmd = ETHTOOL_GPFLAGS
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&curr))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&curr)); err != nil {
 		return err
 	}
 
@@ -1150,7 +1152,7 @@ func (e *Ethtool) UpdatePrivFlags(intf string, config map[string]bool) error {
 		}
 	}
 
-	return e.ioctl(intf, uintptr(unsafe.Pointer(&update)))
+	return e.ioctl(intf, unsafe.Pointer(&update))
 }
 
 // LinkState get the state of a link.
@@ -1159,7 +1161,7 @@ func (e *Ethtool) LinkState(intf string) (uint32, error) {
 		cmd: ETHTOOL_GLINK,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&x))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&x)); err != nil {
 		return 0, err
 	}
 
@@ -1188,7 +1190,7 @@ func (e *Ethtool) StatsWithBuffer(intf string, gstringsPtr *EthtoolGStrings, sta
 		cmd: ETHTOOL_GDRVINFO,
 	}
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&drvinfo))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(&drvinfo)); err != nil {
 		return nil, err
 	}
 
@@ -1200,14 +1202,14 @@ func (e *Ethtool) StatsWithBuffer(intf string, gstringsPtr *EthtoolGStrings, sta
 	gstringsPtr.string_set = ETH_SS_STATS
 	gstringsPtr.len = drvinfo.n_stats
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(gstringsPtr))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(gstringsPtr)); err != nil {
 		return nil, err
 	}
 
 	statsPtr.cmd = ETHTOOL_GSTATS
 	statsPtr.n_stats = drvinfo.n_stats
 
-	if err := e.ioctl(intf, uintptr(unsafe.Pointer(statsPtr))); err != nil {
+	if err := e.ioctl(intf, unsafe.Pointer(statsPtr)); err != nil {
 		return nil, err
 	}
 
@@ -1245,7 +1247,7 @@ func (e *Ethtool) Identity(intf string, duration *time.Duration) error {
 
 func (e *Ethtool) identity(intf string, identity IdentityConf) error {
 	identity.Cmd = ETHTOOL_PHYS_ID
-	return e.ioctl(intf, uintptr(unsafe.Pointer(&identity)))
+	return e.ioctl(intf, unsafe.Pointer(&identity))
 }
 
 // NewEthtool returns a new ethtool handler

--- a/ethtool_cmd.go
+++ b/ethtool_cmd.go
@@ -114,7 +114,7 @@ func (e *Ethtool) CmdGet(ecmd *EthtoolCmd, intf string) (uint32, error) {
 
 	ifr := ifreq{
 		ifr_name: name,
-		ifr_data: uintptr(unsafe.Pointer(ecmd)),
+		ifr_data: unsafe.Pointer(ecmd),
 	}
 
 	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
@@ -142,7 +142,7 @@ func (e *Ethtool) CmdSet(ecmd *EthtoolCmd, intf string) (uint32, error) {
 
 	ifr := ifreq{
 		ifr_name: name,
-		ifr_data: uintptr(unsafe.Pointer(ecmd)),
+		ifr_data: unsafe.Pointer(ecmd),
 	}
 
 	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
@@ -171,7 +171,7 @@ func (e *Ethtool) CmdGetMapped(intf string) (map[string]uint64, error) {
 
 	ifr := ifreq{
 		ifr_name: name,
-		ifr_data: uintptr(unsafe.Pointer(&ecmd)),
+		ifr_data: unsafe.Pointer(&ecmd),
 	}
 
 	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),

--- a/ethtool_link_settings.go
+++ b/ethtool_link_settings.go
@@ -74,7 +74,7 @@ func (e *Ethtool) GetLinkSettings(intf string) (*LinkSettings, error) {
 	// Provide the maximum expected nwords based on our constant
 	req.Settings.LinkModeMasksNwords = int8(MAX_LINK_MODE_MASK_NWORDS)
 
-	err := e.ioctl(intf, uintptr(unsafe.Pointer(&req)))
+	err := e.ioctl(intf, unsafe.Pointer(&req))
 	fallbackReason := ""
 
 	var errno syscall.Errno
@@ -137,7 +137,7 @@ func (e *Ethtool) SetLinkSettings(intf string, settings *LinkSettings) error {
 	checkReq.Settings.Cmd = ETHTOOL_GLINKSETTINGS
 	checkReq.Settings.LinkModeMasksNwords = int8(MAX_LINK_MODE_MASK_NWORDS)
 
-	errGLinkSettings := e.ioctl(intf, uintptr(unsafe.Pointer(&checkReq)))
+	errGLinkSettings := e.ioctl(intf, unsafe.Pointer(&checkReq))
 	canUseGLinkSettings := false
 	nwords := 0
 
@@ -179,7 +179,7 @@ func (e *Ethtool) SetLinkSettings(intf string, settings *LinkSettings) error {
 		copy(setReq.Masks[0*nwords:1*nwords], zeroMaskSupported)
 		copy(setReq.Masks[2*nwords:3*nwords], zeroMaskLp)
 
-		if err := e.ioctl(intf, uintptr(unsafe.Pointer(&setReq))); err != nil {
+		if err := e.ioctl(intf, unsafe.Pointer(&setReq)); err != nil {
 			return fmt.Errorf("ETHTOOL_SLINKSETTINGS ioctl failed: %w", err)
 		}
 		return nil

--- a/ethtool_msglvl.go
+++ b/ethtool_msglvl.go
@@ -47,7 +47,7 @@ func (e *Ethtool) MsglvlGet(intf string) (uint32, error) {
 
 	ifr := ifreq{
 		ifr_name: name,
-		ifr_data: uintptr(unsafe.Pointer(&edata)),
+		ifr_data: unsafe.Pointer(&edata),
 	}
 
 	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
@@ -70,7 +70,7 @@ func (e *Ethtool) MsglvlSet(intf string, valset uint32) (uint32, uint32, error) 
 
 	ifr := ifreq{
 		ifr_name: name,
-		ifr_data: uintptr(unsafe.Pointer(&edata)),
+		ifr_data: unsafe.Pointer(&edata),
 	}
 
 	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),

--- a/ethtool_test.go
+++ b/ethtool_test.go
@@ -24,6 +24,7 @@ package ethtool
 import (
 	"net"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -163,6 +164,67 @@ func TestFeatures(t *testing.T) {
 	if fixed == 0 {
 		// the lo interface MUST have some non-available features, by design
 		t.Fatalf("loopback interface reported all features available")
+	}
+}
+
+// This test exercises Ethtool.FeatureNames at varying stack depths. The callee stack depth
+// should not impact the correctness of the function and so we assert it is equivalent for
+// varying depths.
+// At the time of writing, Ethtool.FeatureNames used unsafe.Pointer incorrectly. A struct was created
+// and cast to uintptr before being passed to Ethtool.ioctl. A uintptr is opaque to the runtime for
+// the purposes of liveness checks and stack copying. If a uintptr argument is stored on the stack
+// and the stack is grown then it will be a dangling pointer to the old stack.
+func TestFeatureNamesStackDepth(t *testing.T) {
+	var callFeatureNamesAtDepth func(*Ethtool, string, int) (map[string]uint, error)
+	callFeatureNamesAtDepth = func(e *Ethtool, intf string, depth int) (map[string]uint, error) {
+		if depth <= 0 {
+			return e.FeatureNames(intf)
+		}
+		var pad [8]byte
+		names, err := callFeatureNamesAtDepth(e, intf, depth-1)
+		runtime.KeepAlive(&pad)
+		return names, err
+	}
+	const intf = "lo"
+
+	e, err := NewEthtool()
+	if err != nil {
+		t.Fatalf("NewEthtool failed: %v", err)
+	}
+	defer e.Close()
+
+	want, err := e.FeatureNames(intf)
+	if err != nil {
+		t.Fatalf("FeatureNames(%q) failed: %v", intf, err)
+	}
+	if len(want) == 0 {
+		t.Fatalf("FeatureNames(%q) returned no features", intf)
+	}
+
+	const maxDepth = 512
+
+	type result struct {
+		names map[string]uint
+		err   error
+	}
+
+	for depth := 0; depth <= maxDepth; depth++ {
+		ch := make(chan result, 1)
+		go func() {
+			names, err := callFeatureNamesAtDepth(e, intf, depth)
+			ch <- result{names: names, err: err}
+		}()
+		got := <-ch
+
+		if got.err != nil {
+			t.Fatalf("FeatureNames(%q) at stack depth=%d returned error: %v", intf, depth, got.err)
+		}
+		if !reflect.DeepEqual(got.names, want) {
+			t.Fatalf(
+				"FeatureNames(%q) incorrect at stack depth=%d: got %d features, want %d.",
+				intf, depth, len(got.names), len(want),
+			)
+		}
 	}
 }
 


### PR DESCRIPTION
- Add test calling FeatureNames at varying stack depths 

Ethtool.getNames can fail when calling the ETHTOOL_GSSET_INFO ioctl if the morestack prologue of Ethtool.ioctl grows the stack. This is because the ssetInfo variable is stored on the stack, and uintptr is opaque and not updated when the stack is moved. 

Add a test `TestFeatureNamesStackDepth` to assert the correctness at varying stack depths. It is expected to fail at this commit and will be fixed in the next. 

```
 --- FAIL: TestFeatureNamesStackDepth (0.00s)
ethtool_test.go:224: FeatureNames("lo") incorrect at stack depth=10: got 0 features, want 60. 
```

- Fix dangling uintptr bugs

A uintptr is opaque to the runtime and so any time an unsafe.Pointer is converted into a uintptr we must ensure that the underlying pointer cannot be invalidated. 

The documentation for [unsafe.Pointer](https://pkg.go.dev/unsafe#Pointer) lists the safe ways to use uintptr. The relevant subsection for this patch is 2), a uintptr has no pointer semantics and it is unsafe to treat it as a live reference except in a limited set of cases. Subsection 4) describes the exception we rely on, that converting unsafe.Pointer to uintptr in an argument is live until the call completes. We'll also store unsafe.Pointer instead of uintptr in the ifreq struct. Both types have the same underlying representation and so this is equivalent to the kernel. 

I chose to introduce a failing test in the first commit so it can be checked out independently and tested. If you'd prefer each commit to be passing, let me know and I can squash or reorder :)